### PR TITLE
join-array & available-fd

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,8 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
+indent_style = space
+indent_size = 2
 
 # Tab indentation (no size specified)
 [Makefile]
@@ -13,9 +15,6 @@ indent_style = tab
 indent_size = 4
 
 [*.bash]
-indent_style = space
-indent_size = 2
-
 shell_variant      = bash  
 binary_next_line   = true  # binary ops like && and | may start a line.
 switch_case_indent = true  # switch cases will be indented.
@@ -26,9 +25,6 @@ never_split        = true  # like -ns
 
 
 [*.bats]
-indent_style = space
-indent_size = 2
-
 shell_variant      = bats  
 binary_next_line   = true  # binary ops like && and | may start a line.
 switch_case_indent = true  # switch cases will be indented.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
         with:
           submodules: 'true'
       - name: Tests
-        run: sudo --user='runner' make test  
+        run: sudo --user='runner' make 'test'
   coverage:
     runs-on: 'ubuntu-latest'
     steps:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ tools provided by a real `bash` framework.
 ## Functions
 
 <!-- brief start -->
+- **[available-fd](./doc/available-fd.md)** : Find first unused file descriptor (fd) (for `bash` < 4.1 (e.g. macOS)).
 - **[cecho](./doc/cecho.md)** : Colored Echo: output text in color.
 - **[check-binary](./doc/check-binary.md)** : Check for the presence of a binary in $PATH.
 - **[download](./doc/download.md)** : Download content from a URL and write it to `/dev/stdout`.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![linting](https://github.com/biapy/biapy-bashlings/actions/workflows/super-linter.yaml/badge.svg)](https://github.com/biapy/biapy-bashlings/actions/workflows/super-linter.yaml)
 [![tests](https://github.com/biapy/biapy-bashlings/actions/workflows/ci.yaml/badge.svg)](https://github.com/biapy/biapy-bashlings/actions/workflows/ci.yaml)
 [![coverage](https://codecov.io/gh/biapy/biapy-bashlings/branch/main/graph/badge.svg?token=4HLU62R4TB)](https://codecov.io/gh/biapy/biapy-bashlings)
+[![CodeFactor](https://www.codefactor.io/repository/github/biapy/biapy-bashlings/badge)](https://www.codefactor.io/repository/github/biapy/biapy-bashlings)
 
 A `bash` functions library.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ tools provided by a real `bash` framework.
 - **[in-list](./doc/in-list.md)** : Test if a value is in a list.
 - **[is-array](./doc/is-array.md)** : Test if a variable is an array.
 - **[is-url](./doc/is-url.md)** : Test if a string is a HTTP, HTTPS, FTP or FILE URL.
+- **[join-array](./doc/join-array.md)** : Join an array contents with a string separator.
 - **[process-options](./doc/process-options.md)** : Alternative getopt for functions.
 - **[realpath-check](./doc/realpath-check.md)** : Resolve the real absolute path and check its existence.
 - **[realpath](./doc/realpath.md)** : Resolve the real absolute path.

--- a/doc/available-fd.md
+++ b/doc/available-fd.md
@@ -21,25 +21,32 @@ This function is useful for `bash` < 4.1 (e.g. macOS).
 
 ```bash
 source "${BASH_SOURCE[0]%/*}/libs/biapy-bashlings/src/available-fd.bash"
-error_fd="$(available-fd || echo -n '2')"; then
-fd_target='&2'
-((quiet)) && fd_target='/dev/null'
-eval "exec ${error_fd}>${fd_target}"
+if error_fd="$(available-fd '2')"; then
+  fd_target='&2'
+  ((quiet)) && fd_target='/dev/null'
+  eval "exec ${error_fd}>${fd_target}"
+fi
 ```
+
+#### Arguments
+
+* **$1** (integer): A default fd is no available fd is found.
 
 #### Exit codes
 
 * **0**: If an available fd is found.
 * **1**: If no fd between 10 and 200 is available.
-* **2**: If argument present.
+* **2**: If more than one argument present.
+* **3**: If `$1` is not an integer.
 
 #### Output on stdout
 
-* The available file descriptor number.
+* The available file descriptor number, or `$1` if none found.
 
 #### Output on stderr
 
-* Error if an argument is present.
+* Error if more than one argument present.
+* Error if argument is not an integer.
 
 #### See also
 

--- a/doc/available-fd.md
+++ b/doc/available-fd.md
@@ -1,0 +1,48 @@
+# src/available-fd.bash
+
+Find first unused file descriptor (fd) (for `bash` < 4.1 (e.g. macOS)).
+
+## Overview
+
+`available-fd` looks for an unused file descriptor and output its number
+on stdout.
+
+## Index
+
+* [available-fd](#available-fd)
+
+### available-fd
+
+`available-fd` looks for an unused file descriptor (fd) in the range 10 to
+200 and output its number on stdout.
+This function is useful for `bash` < 4.1 (e.g. macOS).
+
+#### Example
+
+```bash
+source "${BASH_SOURCE[0]%/*}/libs/biapy-bashlings/src/available-fd.bash"
+error_fd="$(available-fd || echo -n '2')"; then
+fd_target='&2'
+((quiet)) && fd_target='/dev/null'
+eval "exec ${error_fd}>${fd_target}"
+```
+
+#### Exit codes
+
+* **0**: If an available fd is found.
+* **1**: If no fd between 10 and 200 is available.
+* **2**: If argument present.
+
+#### Output on stdout
+
+* The available file descriptor number.
+
+#### Output on stderr
+
+* Error if an argument is present.
+
+#### See also
+
+* [cecho](./cecho.md#cecho).
+* [How to find next available file descriptor in Bash?](https://stackoverflow.com/questions/41603787/how-to-find-next-available-file-descriptor-in-bash/41626332#41626332)
+

--- a/doc/join-array.md
+++ b/doc/join-array.md
@@ -1,0 +1,55 @@
+# src/join-array.bash
+
+Join an array contents with a string separator.
+
+## Overview
+
+`join-array` converts an array to string by joining its values with given
+string.
+
+## Index
+
+* [join-array](#join-array)
+
+### join-array
+
+Join an array contents by a string. It is similar to PHP `implode`
+function.
+The separator allows for escaped special characters (e.g. `\n` and `\t`)
+by being pre-processed with `printf '%b'`
+
+#### Example
+
+```bash
+source "${BASH_SOURCE[0]%/*}/libs/biapy-bashlings/src/join-array.bash"
+declare -a 'example_array'
+example_array=('Dancing' 'on the tune of' 1 'array contents' )
+example_string="$(
+  join-array ' ~8~ ' ${example_array[@]+"${example_array[@]}"}
+)"
+```
+
+#### Arguments
+
+* **$1** (string): The separator used to join the array contents.
+* **...** (mixed): The contents of the joined array.
+
+#### Exit codes
+
+* **0**: If the array contents is join successfully.
+* **1**: If an argument is missing.
+
+#### Output on stdout
+
+* The `$@` array contents joined by `$1` separator.
+
+#### Output on stderr
+
+* Error if an argument is missing.
+
+#### See also
+
+* [cecho](./cecho.md#cecho).
+* [PHP implode()](https://www.php.net/manual/function.implode.php).
+* [How to join() array elements in a bash script](https://dev.to/meleu/how-to-join-array-elements-in-a-bash-script-303a)
+

--- a/doc/repeat-string.md
+++ b/doc/repeat-string.md
@@ -4,7 +4,7 @@ Repeat a string N times.
 
 ## Overview
 
-`repeat-string` output given string repeated N times.
+`repeat-string` outputs given string repeated N times.
 
 ## Index
 

--- a/skeleton.bash
+++ b/skeleton.bash
@@ -14,6 +14,7 @@ script_name="${0-##*/}"
 # script_dir="$(dirname "${0-}")"
 
 # shellcheck source-path=SCRIPTDIR
+source "${BASH_SOURCE[0]%/*}/src/available-fd.bash"
 source "${BASH_SOURCE[0]%/*}/src/cecho.bash"
 source "${BASH_SOURCE[0]%/*}/src/in-list.bash"
 
@@ -87,19 +88,10 @@ EOF
   # See: https://unix.stackexchange.com/questions/28740/bash-use-a-variable-to-store-stderrstdout-redirection
   local fd_target
   local error_fd
-  # For bash < 4.1 (e.g. Mac OS), detect first available file descriptor.
-  # See: https://stackoverflow.com/questions/41603787/how-to-find-next-available-file-descriptor-in-bash
-  error_fd=9
-  while ((++error_fd < 200)); do
-    # shellcheck disable=SC2188 # Ignore a file descriptor availability test.
-    ! <&"${error_fd}" && break
-  done 2> '/dev/null'
-  if ((error_fd < 200)); then
+  if error_fd="$(available-fd '2')"; then
     fd_target='&2'
     ((quiet)) && fd_target='/dev/null'
     eval "exec ${error_fd}>${fd_target}"
-  else
-    error_fd=2
   fi
 
   # For bash >4.1, the above line can be replaced by:
@@ -113,18 +105,11 @@ EOF
   # fi
 
   local verbose_fd
-  verbose_fd=9
-  while ((++verbose_fd < 200)); do
-    # shellcheck disable=SC2188 # Ignore a file descriptor availability test.
-    ! <&"${verbose_fd}" && break
-  done 2> '/dev/null'
-  if ((verbose_fd < 200)); then
+  if verbose_fd="$(available-fd '2')"; then
     fd_target='/dev/null'
     ((verbose)) && fd_target='&2'
     eval "exec ${verbose_fd}>${fd_target}"
-    cecho "DEBUG" "Debug: Verbose mode enabled." >&"${verbose_fd-2}"
-  else
-    verbose_fd=2
+    cecho "DEBUG" "Debug: ${FUNCNAME[0]}'s verbose mode enabled." >&"${verbose_fd-2}"
   fi
 
   # Function closing error redirection file descriptors.

--- a/skeleton.bash
+++ b/skeleton.bash
@@ -89,9 +89,8 @@ EOF
   local fd_target
   local error_fd
   if error_fd="$(available-fd '2')"; then
-    fd_target='&2'
-    ((quiet)) && fd_target='/dev/null'
-    eval "exec ${error_fd}>${fd_target}"
+    ((quiet)) && fd_target='/dev/null' || fd_target='&2'
+    eval "exec ${error_fd-2}>${fd_target-&2}"
   fi
 
   # For bash >4.1, the above line can be replaced by:
@@ -106,9 +105,8 @@ EOF
 
   local verbose_fd
   if verbose_fd="$(available-fd '2')"; then
-    fd_target='/dev/null'
-    ((verbose)) && fd_target='&2'
-    eval "exec ${verbose_fd}>${fd_target}"
+    ((verbose)) && fd_target='&2' || fd_target='/dev/null'
+    eval "exec ${verbose_fd-2}>${fd_target-'/dev/null'}"
     cecho "DEBUG" "Debug: ${FUNCNAME[0]}'s verbose mode enabled." >&"${verbose_fd-2}"
   fi
 

--- a/src/available-fd.bash
+++ b/src/available-fd.bash
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# @file src/available-fd.bash
+# @author [Grisha Levit](https://stackoverflow.com/users/1072229/grisha-levit)
+# @author Pierre-Yves Landuré < contact at biapy dot fr >
+# @brief Find first unused file descriptor (fd) (for `bash` < 4.1 (e.g. macOS)).
+# @description
+#   `available-fd` looks for an unused file descriptor and output its number
+#   on stdout.
+
+# shellcheck source-path=SCRIPTDIR
+source "${BASH_SOURCE[0]%/*}/cecho.bash"
+
+# @description
+#   `available-fd` looks for an unused file descriptor (fd) in the range 10 to
+#   200 and output its number on stdout.
+#   This function is useful for `bash` < 4.1 (e.g. macOS).
+#
+# @example
+#   source "${BASH_SOURCE[0]%/*}/libs/biapy-bashlings/src/available-fd.bash"
+#   error_fd="$(available-fd || echo -n '2')"; then
+#   fd_target='&2'
+#   ((quiet)) && fd_target='/dev/null'
+#   eval "exec ${error_fd}>${fd_target}"
+#
+# @exitcode 0 If an available fd is found.
+# @exitcode 1 If no fd between 10 and 200 is available.
+# @exitcode 2 If argument present.
+#
+# @stdout The available file descriptor number.
+#
+# @stderr Error if an argument is present.
+#
+# @see [cecho](./cecho.md#cecho).
+# @see [How to find next available file descriptor in Bash?](https://stackoverflow.com/questions/41603787/how-to-find-next-available-file-descriptor-in-bash/41626332#41626332)
+function available-fd() {
+  # Requires at least one argument.
+  if [[ ${#} -ne 0 ]]; then
+    cecho "ERROR" "Error: ${FUNCNAME[0]} does not accept arguments." >&2
+    return 2
+  fi
+
+  # Detect OS maximum fd count.
+  max_fd_count="$(ulimit -n)"
+
+  # Limit max_fd count to 200, for an acceptable limit.
+  ((max_fd_count > 200)) && max_fd_count=200
+
+  # See:
+  local checked_fd=9
+  while ((++checked_fd <= max_fd_count)); do
+    # shellcheck disable=SC2188 # Ignore a file descriptor availability test.
+    if ! <&"${checked_fd}"; then
+      # fd is available.
+      echo -n "${checked_fd}"
+      return 0
+    fi
+  done 2> '/dev/null'
+
+  return 1
+}

--- a/src/download.bash
+++ b/src/download.bash
@@ -7,9 +7,10 @@
 #   its contents to `/dev/stdout` or to the specified file path.
 
 # shellcheck source-path=SCRIPTDIR
+source "${BASH_SOURCE[0]%/*}/available-fd.bash"
 source "${BASH_SOURCE[0]%/*}/cecho.bash"
-source "${BASH_SOURCE[0]%/*}/in-list.bash"
 source "${BASH_SOURCE[0]%/*}/check-binary.bash"
+source "${BASH_SOURCE[0]%/*}/in-list.bash"
 source "${BASH_SOURCE[0]%/*}/process-options.bash"
 
 # @description
@@ -64,6 +65,9 @@ function download() {
 
   local binary_path
   local binary
+  local fd_target
+  local error_fd
+  local verbose_fd
   local command_line=()
   local binary_check="wget;curl"
 
@@ -78,38 +82,15 @@ function download() {
   in-list "(-q|--quiet)" ${@+"$@"} && quiet=1
   in-list "(-v|--verbose)" ${@+"$@"} && verbose=1
 
-  # Conditionnal output redirection.
-  # See: https://unix.stackexchange.com/questions/28740/bash-use-a-variable-to-store-stderrstdout-redirection
-  local fd_target
-  local error_fd
-  # For bash < 4.1 (e.g. Mac OS), detect first available file descriptor.
-  # See: https://stackoverflow.com/questions/41603787/how-to-find-next-available-file-descriptor-in-bash
-  error_fd=9
-  while ((++error_fd < 200)); do
-    # shellcheck disable=SC2188 # Ignore a file descriptor availability test.
-    ! <&"${error_fd}" && break
-  done 2> '/dev/null'
-  if ((error_fd < 200)); then
-    fd_target='&2'
-    ((quiet)) && fd_target='/dev/null'
-    eval "exec ${error_fd}>${fd_target}"
-  else
-    error_fd=2
+  if error_fd="$(available-fd '2')"; then
+    ((quiet)) && fd_target='/dev/null' || fd_target='&2'
+    eval "exec ${error_fd-2}>${fd_target-&2}"
   fi
 
-  local verbose_fd
-  verbose_fd=9
-  while ((++verbose_fd < 200)); do
-    # shellcheck disable=SC2188 # Ignore a file descriptor availability test.
-    ! <&"${verbose_fd}" && break
-  done 2> '/dev/null'
-  if ((verbose_fd < 200)); then
-    fd_target='/dev/null'
-    ((verbose)) && fd_target='&2'
-    eval "exec ${verbose_fd}>${fd_target}"
-    cecho "DEBUG" "Debug: Verbose mode enabled." >&"${verbose_fd-2}"
-  else
-    verbose_fd=2
+  if verbose_fd="$(available-fd '2')"; then
+    ((verbose)) && fd_target='&2' || fd_target='/dev/null'
+    eval "exec ${verbose_fd-2}>${fd_target-'/dev/null'}"
+    cecho "DEBUG" "Debug: ${FUNCNAME[0]}'s verbose mode enabled." >&"${verbose_fd-2}"
   fi
 
   # Function closing error redirection file descriptors.

--- a/src/join-array.bash
+++ b/src/join-array.bash
@@ -44,9 +44,9 @@ function join-array() {
     return 1
   fi
 
-  # Get separator & remove it from arguments.
-  local separator
-  printf -v 'separator' '%b' "${1-}"
+  # Get separator, process escaped characters & remove it from arguments.
+  local separator="${1-}"
+  [[ -n "${separator-}" ]] && printf -v 'separator' '%b' "${separator-}"
   shift
 
   # If array is empty, return empty string.

--- a/src/join-array.bash
+++ b/src/join-array.bash
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# @file src/join-array.bash
+# @author [meleu](https://dev.to/meleu)
+# @author Pierre-Yves Landuré < contact at biapy dot fr >
+# @brief Join an array contents with a string separator.
+# @description
+#   `join-array` converts an array to string by joining its values with given
+#   string.
+
+# shellcheck source-path=SCRIPTDIR
+source "${BASH_SOURCE[0]%/*}/cecho.bash"
+
+# @description
+#   Join an array contents by a string. It is similar to PHP `implode`
+#   function.
+#   The separator allows for escaped special characters (e.g. `\n` and `\t`)
+#   by being pre-processed with `printf '%b'`
+#
+# @example
+#   source "${BASH_SOURCE[0]%/*}/libs/biapy-bashlings/src/join-array.bash"
+#   declare -a 'example_array'
+#   example_array=('Dancing' 'on the tune of' 1 'array contents' )
+#   example_string="$(
+#     join-array ' ~8~ ' ${example_array[@]+"${example_array[@]}"}
+#   )"
+#
+# @arg $1 string The separator used to join the array contents.
+# @arg $@ mixed The contents of the joined array.
+#
+# @exitcode 0 If the array contents is join successfully.
+# @exitcode 1 If an argument is missing.
+#
+# @stdout The `$@` array contents joined by `$1` separator.
+#
+# @stderr Error if an argument is missing.
+#
+# @see [cecho](./cecho.md#cecho).
+# @see [PHP implode()](https://www.php.net/manual/function.implode.php).
+# @see [How to join() array elements in a bash script](https://dev.to/meleu/how-to-join-array-elements-in-a-bash-script-303a)
+function join-array() {
+  # Requires at least one argument.
+  if [[ ${#} -eq 0 ]]; then
+    cecho "ERROR" "Error: ${FUNCNAME[0]} requires a separator as first argument." >&2
+    return 1
+  fi
+
+  # Get separator & remove it from arguments.
+  local separator
+  printf -v 'separator' '%b' "${1-}"
+  shift
+
+  # If array is empty, return empty string.
+  if [[ ${#} -eq 0 ]]; then
+    return 0
+  fi
+
+  # Get first value and remove it from arguments.
+  local first_item="${1-}"
+  shift
+
+  # Output contents using printf to prevent word splitting
+  # (i.e. $IFS in output).
+  printf "%s" "${first_item}" "${@/#/${separator}}"
+  return
+}

--- a/src/realpath-check.bash
+++ b/src/realpath-check.bash
@@ -8,6 +8,7 @@
 #     and returns an error code if the path does not exists.
 
 # shellcheck source-path=SCRIPTDIR
+source "${BASH_SOURCE[0]%/*}/available-fd.bash"
 source "${BASH_SOURCE[0]%/*}/cecho.bash"
 source "${BASH_SOURCE[0]%/*}/in-list.bash"
 source "${BASH_SOURCE[0]%/*}/process-options.bash"
@@ -50,6 +51,8 @@ function realpath-check() {
   local e=0
   local exit=0
 
+  local fd_target
+  local error_fd
   local path=''
   local realpath=''
 
@@ -57,20 +60,9 @@ function realpath-check() {
   in-list "(-q|--quiet)" ${@+"$@"} && quiet=1
 
   # Conditionnal output redirection.
-  local fd_target
-  local error_fd
-  # Detect first available file descriptor for Bash < 4.1
-  error_fd=9
-  while ((++error_fd < 200)); do
-    # shellcheck disable=SC2188 # Ignore a file descriptor availability test.
-    ! <&"${error_fd}" && break
-  done 2> '/dev/null'
-  if ((error_fd < 200)); then
-    fd_target='&2'
-    ((quiet)) && fd_target='/dev/null'
-    eval "exec ${error_fd}>${fd_target}"
-  else
-    error_fd=2
+  if error_fd="$(available-fd '2')"; then
+    ((quiet)) && fd_target='/dev/null' || fd_target='&2'
+    eval "exec ${error_fd-2}>${fd_target-&2}"
   fi
 
   # Function closing error redirection file descriptors.

--- a/src/repeat-string.bash
+++ b/src/repeat-string.bash
@@ -42,17 +42,17 @@ function repeat-string() {
   local spacing=""
 
   # Ensure quantity is an integer
-  if [[ -z "${quantity}" || ! "${quantity}" =~ ^[0-9]+$ ]]; then
+  if [[ -z "${quantity-}" || ! "${quantity-0}" =~ ^[0-9]+$ ]]; then
     cecho "ERROR" "Error: ${FUNCNAME[0]}'s first argument is not an integer." >&"${error_fd-2}"
     return 2
   fi
 
   # Use printf to create an empty string with $quantity spaces.
   # shellcheck disable=SC2183
-  printf -v 'spacing' '%*s' "${quantity}"
+  printf -v 'spacing' '%*s' "${quantity-0}"
 
   # Replace the $quantity spaces by the string to be repeated.
-  echo -n "${spacing// /${repeated}}"
+  echo -n "${spacing// /${repeated-}}"
 
   return 0
 }

--- a/src/repeat-string.bash
+++ b/src/repeat-string.bash
@@ -43,7 +43,7 @@ function repeat-string() {
 
   # Ensure quantity is an integer
   if [[ -z "${quantity-}" || ! "${quantity-0}" =~ ^[0-9]+$ ]]; then
-    cecho "ERROR" "Error: ${FUNCNAME[0]}'s first argument is not an integer." >&"${error_fd-2}"
+    cecho "ERROR" "Error: ${FUNCNAME[0]}'s first argument is not an integer." >&2
     return 2
   fi
 

--- a/src/repeat-string.bash
+++ b/src/repeat-string.bash
@@ -4,7 +4,7 @@
 # @author Pierre-Yves Landuré < contact at biapy dot fr >
 # @brief Repeat a string N times.
 # @description
-#   `repeat-string` output given string repeated N times.
+#   `repeat-string` outputs given string repeated N times.
 
 # shellcheck source-path=SCRIPTDIR
 source "${BASH_SOURCE[0]%/*}/cecho.bash"

--- a/test/available-fd.bats
+++ b/test/available-fd.bats
@@ -22,9 +22,15 @@ teardown() {
 # bats file_tags=function:available-fd,scope:public
 
 @test "fail with error on argument present" {
-  run available-fd 'forbidden'
+  run available-fd '2' 'forbidden'
   assert_failure
-  assert_output "Error: available-fd does not accept arguments."
+  assert_output "Error: available-fd accepts only one argument."
+}
+
+@test "fail with error if first argument is not an integer" {
+  run available-fd 'string'
+  assert_failure
+  assert_output "Error: available-fd's first argument is not an integer."
 }
 
 @test "detect an available file descriptor" {
@@ -47,7 +53,7 @@ teardown() {
   eval "exec ${available_fd}>&-"
 }
 
-@test "find up to 190 available file descriptors" {
+@test "return default fd when no fd is available." {
   # Exaust all available fds.
   declare -a opened_fds
   opened_fds=()
@@ -56,9 +62,9 @@ teardown() {
     opened_fds+=("${available_fd}")
   done
 
-  run available-fd
+  run available-fd '2'
   assert_failure
-  assert_output ''
+  assert_output '2'
 
   # Close opened fds.
   for opened_fd in ${opened_fds[@]+"${opened_fds[@]}"}; do

--- a/test/available-fd.bats
+++ b/test/available-fd.bats
@@ -41,6 +41,7 @@ teardown() {
 
 @test "detect next available file descriptor when an file descriptor is used" {
   # Open an available fd.
+  # shellcheck disable=SC2119 # $(available-fd) does not need arguments
   available_fd="$(available-fd)"
   eval "exec ${available_fd}>/dev/null"
 
@@ -57,6 +58,7 @@ teardown() {
   # Exaust all available fds.
   declare -a opened_fds
   opened_fds=()
+  # shellcheck disable=SC2119 # $(available-fd) does not need arguments
   while available_fd="$(available-fd)"; do
     eval "exec ${available_fd}>/dev/null"
     opened_fds+=("${available_fd}")

--- a/test/available-fd.bats
+++ b/test/available-fd.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+# available-fd.bats
+# Test available-fd.bash:available-fd function.
+
+# shellcheck source-path=SCRIPTDIR../src
+
+# Setup test environment.
+setup() {
+  # Load bats libraries.
+  load 'test_helper/common-setup'
+  _common_setup
+
+  # Sourcing available-fd.bash
+  source "${PROJECT_ROOT}/src/available-fd.bash"
+}
+
+# Teardown test environment.
+teardown() {
+  _common_teardown
+}
+
+# bats file_tags=function:available-fd,scope:public
+
+@test "fail with error on argument present" {
+  run available-fd 'forbidden'
+  assert_failure
+  assert_output "Error: available-fd does not accept arguments."
+}
+
+@test "detect an available file descriptor" {
+  run available-fd
+  assert_success
+  assert_output --regexp '^[0-9]+$'
+}
+
+@test "detect next available file descriptor when an file descriptor is used" {
+  # Open an available fd.
+  available_fd="$(available-fd)"
+  eval "exec ${available_fd}>/dev/null"
+
+  run available-fd
+  assert_success
+  refute_output "${available_fd}"
+  assert_output --regexp '^[0-9]+$'
+
+  # Close opened fd.
+  eval "exec ${available_fd}>&-"
+}
+
+@test "find up to 190 available file descriptors" {
+  # Exaust all available fds.
+  declare -a opened_fds
+  opened_fds=()
+  while available_fd="$(available-fd)"; do
+    eval "exec ${available_fd}>/dev/null"
+    opened_fds+=("${available_fd}")
+  done
+
+  run available-fd
+  assert_failure
+  assert_output ''
+
+  # Close opened fds.
+  for opened_fd in ${opened_fds[@]+"${opened_fds[@]}"}; do
+    eval "exec ${opened_fd}>&-"
+  done
+}

--- a/test/check-binary.bats
+++ b/test/check-binary.bats
@@ -6,50 +6,50 @@
 
 # Setup test environment.
 setup() {
-    # Load bats libraries.
-    load 'test_helper/common-setup'
-    load 'test_helper/files-setup'
-    _common_setup
-    _files_setup
+  # Load bats libraries.
+  load 'test_helper/common-setup'
+  load 'test_helper/files-setup'
+  _common_setup
+  _files_setup
 
-    # Sourcing check-binary.bash
-    source "${PROJECT_ROOT}/src/check-binary.bash"
+  # Sourcing check-binary.bash
+  source "${PROJECT_ROOT}/src/check-binary.bash"
 }
 
 # Teardown test environment.
 teardown() {
-    _common_teardown
-    _files_teardown
+  _common_teardown
+  _files_teardown
 }
 
 # bats file_tags=function:check-binary,scope:public
 
 @test "fail on missing argument" {
-    run check-binary "first-arg"
-    assert_failure
-    assert_output "Error: check-binary requires two and only two arguments."
+  run check-binary "first-arg"
+  assert_failure
+  assert_output "Error: check-binary requires two and only two arguments."
 }
 
 @test "fail on more than two arguments" {
-    run check-binary "first-arg" "second-arg" "third-arg"
-    assert_failure
-    assert_output "Error: check-binary requires two and only two arguments."
+  run check-binary "first-arg" "second-arg" "third-arg"
+  assert_failure
+  assert_output "Error: check-binary requires two and only two arguments."
 }
 
 @test "get existing binary path" {
-    run check-binary "sh" "package-name"
-    assert_success
-    assert_output "$(type -p 'sh')"
+  run check-binary "sh" "package-name"
+  assert_success
+  assert_output "$(type -p 'sh')"
 }
 
 @test "get alternative existing binary path" {
-    run check-binary "dummy-non-existant-binary;sh" "package-name"
-    assert_success
-    assert_output "$(type -p 'sh')"
+  run check-binary "dummy-non-existant-binary;sh" "package-name"
+  assert_success
+  assert_output "$(type -p 'sh')"
 }
 
 @test "get package name prompt for missing binary" {
-    run check-binary "dummy-non-existant-binary" "package-name"
-    assert_failure
-    assert_output "Error: 'dummy-non-existant-binary' is missing. Please install package 'package-name'."
+  run check-binary "dummy-non-existant-binary" "package-name"
+  assert_failure
+  assert_output "Error: 'dummy-non-existant-binary' is missing. Please install package 'package-name'."
 }

--- a/test/download.bats
+++ b/test/download.bats
@@ -6,377 +6,377 @@
 
 # Setup test environment.
 setup() {
-    # Load bats libraries.
-    load 'test_helper/common-setup'
-    load 'test_helper/files-setup'
+  # Load bats libraries.
+  load 'test_helper/common-setup'
+  load 'test_helper/files-setup'
 
-    _common_setup
-    _files_setup
+  _common_setup
+  _files_setup
 
-    # Sourcing download.bash
-    source "${PROJECT_ROOT}/src/download.bash"
+  # Sourcing download.bash
+  source "${PROJECT_ROOT}/src/download.bash"
 
-    WORKING_URL="https://raw.githubusercontent.com/github/gitignore/5342e13bc99d1e106b4d5f7bc9e9deaa0c58543e/Ada.gitignore"
-    WORKING_URL_CONTENTS=(
-        "# Object file"
-        "*.o"
-        ""
-        "# Ada Library Information"
-        "*.ali"
+  WORKING_URL="https://raw.githubusercontent.com/github/gitignore/5342e13bc99d1e106b4d5f7bc9e9deaa0c58543e/Ada.gitignore"
+  WORKING_URL_CONTENTS=(
+      "# Object file"
+      "*.o"
+      ""
+      "# Ada Library Information"
+      "*.ali"
   )
-    ERROR_404_URL="https://github.com/404"
+  ERROR_404_URL="https://github.com/404"
 
-    # Create a random User Agent
-    # RANDOM_USER_AGENT="$( command tr --complement --delete \
-    #         '[:alnum:]#%(),-' \
-    #         2>'/dev/null' < '/dev/urandom' \
-    #     | command head --bytes=64
-    # )"
-    RANDOM_USER_AGENT="cshqS1u%0q(MwSF2HAJtqwpdHqAFkcxhANNqcULOT4X(-O7YOE))t)arVVBV#8y"
+  # Create a random User Agent
+  # RANDOM_USER_AGENT="$( command tr --complement --delete \
+  #         '[:alnum:]#%(),-' \
+  #         2>'/dev/null' < '/dev/urandom' \
+  #     | command head --bytes=64
+  # )"
+  RANDOM_USER_AGENT="cshqS1u%0q(MwSF2HAJtqwpdHqAFkcxhANNqcULOT4X(-O7YOE))t)arVVBV#8y"
 }
 
 # Teardown test environment.
 teardown() {
-    _common_teardown
+  _common_teardown
 }
 
 # bats file_tags=function:download,scope:public
 
 @test "fail for missing URL" {
-    run download
-    assert_failure
-    assert_output "Error: download requires URL."
+  run download
+  assert_failure
+  assert_output "Error: download requires URL."
 }
 
 @test "fail quietly for missing URL" {
-    run download --quiet
-    assert_failure
-    assert_output ""
+  run download --quiet
+  assert_failure
+  assert_output ""
 }
 
 @test "fail for both --url and \$1 argument" {
-    run download --url="${ERROR_404_URL}" "${ERROR_404_URL}"
-    assert_failure
-    assert_output "Error: either provide URL via --url or \$1, not both."
+  run download --url="${ERROR_404_URL}" "${ERROR_404_URL}"
+  assert_failure
+  assert_output "Error: either provide URL via --url or \$1, not both."
 }
 
 @test "fail quietly for both --url and \$1 argument" {
-    run download --quiet --url="${ERROR_404_URL}" "${ERROR_404_URL}"
-    assert_failure
-    assert_output ""
+  run download --quiet --url="${ERROR_404_URL}" "${ERROR_404_URL}"
+  assert_failure
+  assert_output ""
 }
 
 @test "fail for too many arguments (with --url)" {
-    run download --url="${ERROR_404_URL}" "${ERROR_404_URL}" "dummy"
-    assert_failure
-    assert_output "Error: download accept at most one argument, or --url option."
+  run download --url="${ERROR_404_URL}" "${ERROR_404_URL}" "dummy"
+  assert_failure
+  assert_output "Error: download accept at most one argument, or --url option."
 }
 
 @test "fail quietly for too many arguments (with --url)" {
-    run download --quiet --url="${ERROR_404_URL}" "${ERROR_404_URL}" "dummy"
-    assert_failure
-    assert_output ""
+  run download --quiet --url="${ERROR_404_URL}" "${ERROR_404_URL}" "dummy"
+  assert_failure
+  assert_output ""
 }
 
 @test "fail for too many arguments (without --url)" {
-    run download "${ERROR_404_URL}" "dummy"
-    assert_failure
-    assert_output "Error: download accept at most one argument, or --url option."
+  run download "${ERROR_404_URL}" "dummy"
+  assert_failure
+  assert_output "Error: download accept at most one argument, or --url option."
 }
 
 @test "fail for 404 URL (as argument)" {
-    run download "${ERROR_404_URL}"
-    assert_failure
-    assert_output "Error: download failed."
+  run download "${ERROR_404_URL}"
+  assert_failure
+  assert_output "Error: download failed."
 }
 
 @test "fail for 404 URL" {
-    run download --url="${ERROR_404_URL}"
-    assert_failure
-    assert_output "Error: download failed."
+  run download --url="${ERROR_404_URL}"
+  assert_failure
+  assert_output "Error: download failed."
 }
 
 @test "fail silently for missing URL (-q)" {
-    run download -q "${ERROR_404_URL}"
-    assert_failure
-    assert_output ""
+  run download -q "${ERROR_404_URL}"
+  assert_failure
+  assert_output ""
 }
 
 @test "fail silently for missing URL (--quiet)" {
-    run download --quiet "${ERROR_404_URL}"
-    assert_failure
-    assert_output ""
+  run download --quiet "${ERROR_404_URL}"
+  assert_failure
+  assert_output ""
 }
 
 @test "fail silentlty for 404 URL (-q)" {
-    run download -q --url="${ERROR_404_URL}"
-    assert_failure
-    assert_output ""
+  run download -q --url="${ERROR_404_URL}"
+  assert_failure
+  assert_output ""
 }
 
 @test "fail silentlty for 404 URL (--quiet)" {
-    run download --quiet --url="${ERROR_404_URL}"
-    assert_failure
-    assert_output ""
+  run download --quiet --url="${ERROR_404_URL}"
+  assert_failure
+  assert_output ""
 }
 
 @test "success for simple HTTPS URL" {
-    bats_require_minimum_version '1.5.0'
-    # Check specific commit content for small file.
-    run --keep-empty-lines download \
-        --url="${WORKING_URL}"
-    assert_success
-    assert_line --index 0 "${WORKING_URL_CONTENTS[0]}"
-    assert_line --index 1 "${WORKING_URL_CONTENTS[1]}"
-    assert_line --index 2 "${WORKING_URL_CONTENTS[2]}"
-    assert_line --index 3 "${WORKING_URL_CONTENTS[3]}"
-    assert_line --index 4 "${WORKING_URL_CONTENTS[4]}"
+  bats_require_minimum_version '1.5.0'
+  # Check specific commit content for small file.
+  run --keep-empty-lines download \
+      --url="${WORKING_URL}"
+  assert_success
+  assert_line --index 0 "${WORKING_URL_CONTENTS[0]}"
+  assert_line --index 1 "${WORKING_URL_CONTENTS[1]}"
+  assert_line --index 2 "${WORKING_URL_CONTENTS[2]}"
+  assert_line --index 3 "${WORKING_URL_CONTENTS[3]}"
+  assert_line --index 4 "${WORKING_URL_CONTENTS[4]}"
 }
 
 @test "success for simple HTTPS URL with dash output" {
-    bats_require_minimum_version '1.5.0'
-    # Check specific commit content for small file.
-    run --keep-empty-lines download --outputPath=- \
-        --url="${WORKING_URL}"
-    assert_success
-    assert_line --index 0 "${WORKING_URL_CONTENTS[0]}"
-    assert_line --index 1 "${WORKING_URL_CONTENTS[1]}"
-    assert_line --index 2 "${WORKING_URL_CONTENTS[2]}"
-    assert_line --index 3 "${WORKING_URL_CONTENTS[3]}"
-    assert_line --index 4 "${WORKING_URL_CONTENTS[4]}"
+  bats_require_minimum_version '1.5.0'
+  # Check specific commit content for small file.
+  run --keep-empty-lines download --outputPath=- \
+      --url="${WORKING_URL}"
+  assert_success
+  assert_line --index 0 "${WORKING_URL_CONTENTS[0]}"
+  assert_line --index 1 "${WORKING_URL_CONTENTS[1]}"
+  assert_line --index 2 "${WORKING_URL_CONTENTS[2]}"
+  assert_line --index 3 "${WORKING_URL_CONTENTS[3]}"
+  assert_line --index 4 "${WORKING_URL_CONTENTS[4]}"
 }
 
 @test "success for simple HTTPS URL with output to file" {
-    # Check specific commit content for small file.
-    run download \
-        --output-path="${MISSING_FILE}" \
-        --url="${WORKING_URL}"
-    assert_success
-    assert_output ''
-    assert_file_exists "${MISSING_FILE}"
-    assert_file_not_empty "${MISSING_FILE}"
+  # Check specific commit content for small file.
+  run download \
+      --output-path="${MISSING_FILE}" \
+      --url="${WORKING_URL}"
+  assert_success
+  assert_output ''
+  assert_file_exists "${MISSING_FILE}"
+  assert_file_not_empty "${MISSING_FILE}"
 
-    # Bash 4 version: mapfile -t "file_contents" < "${MISSING_FILE}"
-    unset -v 'file_contents'
-    declare -a file_contents=()
-    # shellcheck disable=SC2030,SC2031
-    while IFS='' read -r; do file_contents+=("${REPLY}"); done < "${MISSING_FILE}"
-    [[ ${REPLY} ]] && file_contents+=("${REPLY}")
+  # Bash 4 version: mapfile -t "file_contents" < "${MISSING_FILE}"
+  unset -v 'file_contents'
+  declare -a file_contents=()
+  # shellcheck disable=SC2030,SC2031
+  while IFS='' read -r; do file_contents+=("${REPLY}"); done < "${MISSING_FILE}"
+  [[ ${REPLY} ]] && file_contents+=("${REPLY}")
 
-    [[ "${file_contents[0]}" = "${WORKING_URL_CONTENTS[0]}" ]]
-    [[ "${file_contents[1]}" = "${WORKING_URL_CONTENTS[1]}" ]]
-    [[ "${file_contents[2]}" = "${WORKING_URL_CONTENTS[2]}" ]]
-    [[ "${file_contents[3]}" = "${WORKING_URL_CONTENTS[3]}" ]]
-    [[ "${file_contents[4]}" = "${WORKING_URL_CONTENTS[4]}" ]]
+  [[ "${file_contents[0]}" = "${WORKING_URL_CONTENTS[0]}" ]]
+  [[ "${file_contents[1]}" = "${WORKING_URL_CONTENTS[1]}" ]]
+  [[ "${file_contents[2]}" = "${WORKING_URL_CONTENTS[2]}" ]]
+  [[ "${file_contents[3]}" = "${WORKING_URL_CONTENTS[3]}" ]]
+  [[ "${file_contents[4]}" = "${WORKING_URL_CONTENTS[4]}" ]]
 }
 
 @test "success for simple HTTPS URL with deprecated output to file" {
-    # Check specific commit content for small file.
-    run download \
-        --outputPath="${MISSING_FILE}" \
-        --url="${WORKING_URL}"
-    assert_success
-    assert_output ''
-    assert_file_exists "${MISSING_FILE}"
-    assert_file_not_empty "${MISSING_FILE}"
+  # Check specific commit content for small file.
+  run download \
+      --outputPath="${MISSING_FILE}" \
+      --url="${WORKING_URL}"
+  assert_success
+  assert_output ''
+  assert_file_exists "${MISSING_FILE}"
+  assert_file_not_empty "${MISSING_FILE}"
 
-    # Bash 4 version: mapfile -t "file_contents" < "${MISSING_FILE}"
-    unset -v 'file_contents'
-    declare -a file_contents=()
-    # shellcheck disable=SC2030,SC2031
-    while IFS='' read -r; do file_contents+=("${REPLY}"); done < "${MISSING_FILE}"
-    [[ ${REPLY} ]] && file_contents+=("${REPLY}")
+  # Bash 4 version: mapfile -t "file_contents" < "${MISSING_FILE}"
+  unset -v 'file_contents'
+  declare -a file_contents=()
+  # shellcheck disable=SC2030,SC2031
+  while IFS='' read -r; do file_contents+=("${REPLY}"); done < "${MISSING_FILE}"
+  [[ ${REPLY} ]] && file_contents+=("${REPLY}")
 
-    [[ "${file_contents[0]}" = "${WORKING_URL_CONTENTS[0]}" ]]
-    [[ "${file_contents[1]}" = "${WORKING_URL_CONTENTS[1]}" ]]
-    [[ "${file_contents[2]}" = "${WORKING_URL_CONTENTS[2]}" ]]
-    [[ "${file_contents[3]}" = "${WORKING_URL_CONTENTS[3]}" ]]
-    [[ "${file_contents[4]}" = "${WORKING_URL_CONTENTS[4]}" ]]
+  [[ "${file_contents[0]}" = "${WORKING_URL_CONTENTS[0]}" ]]
+  [[ "${file_contents[1]}" = "${WORKING_URL_CONTENTS[1]}" ]]
+  [[ "${file_contents[2]}" = "${WORKING_URL_CONTENTS[2]}" ]]
+  [[ "${file_contents[3]}" = "${WORKING_URL_CONTENTS[3]}" ]]
+  [[ "${file_contents[4]}" = "${WORKING_URL_CONTENTS[4]}" ]]
 }
 
 @test "fail for 404 URL and remove file" {
-    run download \
-        --output-path="${EXISTING_FILE}" \
-        --url="${ERROR_404_URL}"
-    assert_failure
-    assert_output 'Error: download failed.'
-    assert_file_not_exists "${EXISTING_FILE}"
+  run download \
+      --output-path="${EXISTING_FILE}" \
+      --url="${ERROR_404_URL}"
+  assert_failure
+  assert_output 'Error: download failed.'
+  assert_file_not_exists "${EXISTING_FILE}"
 }
 
 @test "success for user agent change" {
-    # Use a user-agent checking web service.
-    run download --user-agent="${RANDOM_USER_AGENT}" \
-        --url="https://www.whatsmyua.info/"
-    assert_success
-    assert_output --partial "${RANDOM_USER_AGENT}"
+  # Use a user-agent checking web service.
+  run download --user-agent="${RANDOM_USER_AGENT}" \
+      --url="https://www.whatsmyua.info/"
+  assert_success
+  assert_output --partial "${RANDOM_USER_AGENT}"
 }
 
 @test "success for deprecated user agent change" {
-    # Use a user-agent checking web service.
-    run download --userAgent="${RANDOM_USER_AGENT}" \
-        --url="https://www.whatsmyua.info/"
-    assert_success
-    assert_output --partial "${RANDOM_USER_AGENT}"
+  # Use a user-agent checking web service.
+  run download --userAgent="${RANDOM_USER_AGENT}" \
+      --url="https://www.whatsmyua.info/"
+  assert_success
+  assert_output --partial "${RANDOM_USER_AGENT}"
 }
 
 @test "check verbose mode" {
-    run download --verbose --url="${ERROR_404_URL}"
-    assert_failure
-    assert_output --partial "Info: download: checking for wget or curl."
+  run download --verbose --url="${ERROR_404_URL}"
+  assert_failure
+  assert_output --partial "Info: download: checking for wget or curl."
 }
 
 @test "--wget: check verbose mode" {
-    run download --wget --verbose --url="${ERROR_404_URL}"
-    assert_failure
-    assert_output --partial "Info: download: checking for wget."
+  run download --wget --verbose --url="${ERROR_404_URL}"
+  assert_failure
+  assert_output --partial "Info: download: checking for wget."
 }
 
 @test "--curl: check verbose mode" {
-    run download --curl --verbose --url="${ERROR_404_URL}"
-    assert_failure
-    assert_output --partial "Info: download: checking for curl."
+  run download --curl --verbose --url="${ERROR_404_URL}"
+  assert_failure
+  assert_output --partial "Info: download: checking for curl."
 }
 
 @test "--wget: fail for 404 URL" {
-    run download --wget --url="${ERROR_404_URL}"
-    assert_failure
-    assert_output "Error: download failed."
+  run download --wget --url="${ERROR_404_URL}"
+  assert_failure
+  assert_output "Error: download failed."
 }
 
 @test "--wget: fail silentlty for 404 URL (-q)" {
-    run download --wget -q --url="${ERROR_404_URL}"
-    assert_failure
-    assert_output ""
+  run download --wget -q --url="${ERROR_404_URL}"
+  assert_failure
+  assert_output ""
 }
 
 @test "--wget: fail silentlty for 404 URL (--quiet)" {
-    run download --wget --quiet --url="${ERROR_404_URL}"
-    assert_failure
-    assert_output ""
+  run download --wget --quiet --url="${ERROR_404_URL}"
+  assert_failure
+  assert_output ""
 }
 
 @test "--wget: success for simple HTTPS URL" {
-    bats_require_minimum_version '1.5.0'
-    # Check specific commit content for small file.
-    run --keep-empty-lines download --wget \
-        --url="${WORKING_URL}"
-    assert_success
-    assert_line --index 0 "${WORKING_URL_CONTENTS[0]}"
-    assert_line --index 1 "${WORKING_URL_CONTENTS[1]}"
-    assert_line --index 2 "${WORKING_URL_CONTENTS[2]}"
-    assert_line --index 3 "${WORKING_URL_CONTENTS[3]}"
-    assert_line --index 4 "${WORKING_URL_CONTENTS[4]}"
+  bats_require_minimum_version '1.5.0'
+  # Check specific commit content for small file.
+  run --keep-empty-lines download --wget \
+      --url="${WORKING_URL}"
+  assert_success
+  assert_line --index 0 "${WORKING_URL_CONTENTS[0]}"
+  assert_line --index 1 "${WORKING_URL_CONTENTS[1]}"
+  assert_line --index 2 "${WORKING_URL_CONTENTS[2]}"
+  assert_line --index 3 "${WORKING_URL_CONTENTS[3]}"
+  assert_line --index 4 "${WORKING_URL_CONTENTS[4]}"
 }
 
 @test "--wget: success for simple HTTPS URL with output to file" {
-    # Check specific commit content for small file.
-    run download --wget \
-        --output-path="${MISSING_FILE}" \
-        --url="${WORKING_URL}"
-    assert_success
-    assert_output ''
-    assert_file_exists "${MISSING_FILE}"
-    assert_file_not_empty "${MISSING_FILE}"
+  # Check specific commit content for small file.
+  run download --wget \
+      --output-path="${MISSING_FILE}" \
+      --url="${WORKING_URL}"
+  assert_success
+  assert_output ''
+  assert_file_exists "${MISSING_FILE}"
+  assert_file_not_empty "${MISSING_FILE}"
 
-    # Bash 4 version: mapfile -t "file_contents" < "${MISSING_FILE}"
-    unset -v 'file_contents'
-    declare -a file_contents=()
-    # shellcheck disable=SC2030,SC2031
-    while IFS='' read -r; do file_contents+=("${REPLY}"); done < "${MISSING_FILE}"
-    [[ ${REPLY} ]] && file_contents+=("${REPLY}")
+  # Bash 4 version: mapfile -t "file_contents" < "${MISSING_FILE}"
+  unset -v 'file_contents'
+  declare -a file_contents=()
+  # shellcheck disable=SC2030,SC2031
+  while IFS='' read -r; do file_contents+=("${REPLY}"); done < "${MISSING_FILE}"
+  [[ ${REPLY} ]] && file_contents+=("${REPLY}")
 
-    [[ "${file_contents[0]}" = "${WORKING_URL_CONTENTS[0]}" ]]
-    [[ "${file_contents[1]}" = "${WORKING_URL_CONTENTS[1]}" ]]
-    [[ "${file_contents[2]}" = "${WORKING_URL_CONTENTS[2]}" ]]
-    [[ "${file_contents[3]}" = "${WORKING_URL_CONTENTS[3]}" ]]
-    [[ "${file_contents[4]}" = "${WORKING_URL_CONTENTS[4]}" ]]
+  [[ "${file_contents[0]}" = "${WORKING_URL_CONTENTS[0]}" ]]
+  [[ "${file_contents[1]}" = "${WORKING_URL_CONTENTS[1]}" ]]
+  [[ "${file_contents[2]}" = "${WORKING_URL_CONTENTS[2]}" ]]
+  [[ "${file_contents[3]}" = "${WORKING_URL_CONTENTS[3]}" ]]
+  [[ "${file_contents[4]}" = "${WORKING_URL_CONTENTS[4]}" ]]
 }
 
 @test "--wget: fail for 404 URL and remove file" {
-    run download --wget \
-        --output-path="${EXISTING_FILE}" \
-        --url="${ERROR_404_URL}"
-    assert_failure
-    assert_output 'Error: download failed.'
-    assert_file_not_exists "${EXISTING_FILE}"
+  run download --wget \
+      --output-path="${EXISTING_FILE}" \
+      --url="${ERROR_404_URL}"
+  assert_failure
+  assert_output 'Error: download failed.'
+  assert_file_not_exists "${EXISTING_FILE}"
 }
 
 @test "--wget: success for user agent change" {
-    # Use a user-agent checking web service.
-    run download --wget --user-agent="${RANDOM_USER_AGENT}" \
-        --url="https://www.whatsmyua.info/"
-    assert_success
-    assert_output --partial "${RANDOM_USER_AGENT}"
+  # Use a user-agent checking web service.
+  run download --wget --user-agent="${RANDOM_USER_AGENT}" \
+      --url="https://www.whatsmyua.info/"
+  assert_success
+  assert_output --partial "${RANDOM_USER_AGENT}"
 }
 
 @test "--curl: fail for 404 URL" {
-    run download --curl --url="${ERROR_404_URL}"
-    assert_failure
-    assert_output "Error: download failed."
+  run download --curl --url="${ERROR_404_URL}"
+  assert_failure
+  assert_output "Error: download failed."
 }
 
 @test "--curl: fail silentlty for 404 URL (-q)" {
-    run download --curl -q --url="${ERROR_404_URL}"
-    assert_failure
-    assert_output ""
+  run download --curl -q --url="${ERROR_404_URL}"
+  assert_failure
+  assert_output ""
 }
 
 @test "--curl: fail silentlty for 404 URL (--quiet)" {
-    run download --curl --quiet --url="${ERROR_404_URL}"
-    assert_failure
-    assert_output ""
+  run download --curl --quiet --url="${ERROR_404_URL}"
+  assert_failure
+  assert_output ""
 }
 
 @test "--curl: success for simple HTTPS URL" {
-    bats_require_minimum_version '1.5.0'
-    # Check specific commit content for small file.
-    run --keep-empty-lines download --curl \
-        --url="${WORKING_URL}"
-    assert_success
-    assert_line --index 0 "${WORKING_URL_CONTENTS[0]}"
-    assert_line --index 1 "${WORKING_URL_CONTENTS[1]}"
-    assert_line --index 2 "${WORKING_URL_CONTENTS[2]}"
-    assert_line --index 3 "${WORKING_URL_CONTENTS[3]}"
-    assert_line --index 4 "${WORKING_URL_CONTENTS[4]}"
+  bats_require_minimum_version '1.5.0'
+  # Check specific commit content for small file.
+  run --keep-empty-lines download --curl \
+      --url="${WORKING_URL}"
+  assert_success
+  assert_line --index 0 "${WORKING_URL_CONTENTS[0]}"
+  assert_line --index 1 "${WORKING_URL_CONTENTS[1]}"
+  assert_line --index 2 "${WORKING_URL_CONTENTS[2]}"
+  assert_line --index 3 "${WORKING_URL_CONTENTS[3]}"
+  assert_line --index 4 "${WORKING_URL_CONTENTS[4]}"
 }
 
 @test "--curl: success for simple HTTPS URL with output to file" {
-    # Check specific commit content for small file.
-    run download --curl \
-        --output-path="${MISSING_FILE}" \
-        --url="${WORKING_URL}"
-    assert_success
-    assert_output ''
-    assert_file_exists "${MISSING_FILE}"
-    assert_file_not_empty "${MISSING_FILE}"
+  # Check specific commit content for small file.
+  run download --curl \
+      --output-path="${MISSING_FILE}" \
+      --url="${WORKING_URL}"
+  assert_success
+  assert_output ''
+  assert_file_exists "${MISSING_FILE}"
+  assert_file_not_empty "${MISSING_FILE}"
 
-    # Bash 4 version: mapfile -t "file_contents" < "${MISSING_FILE}"
-    unset -v 'file_contents'
-    declare -a file_contents=()
-    # shellcheck disable=SC2030,SC2031
-    while IFS='' read -r; do file_contents+=("${REPLY}"); done < "${MISSING_FILE}"
-    [[ ${REPLY} ]] && file_contents+=("${REPLY}")
+  # Bash 4 version: mapfile -t "file_contents" < "${MISSING_FILE}"
+  unset -v 'file_contents'
+  declare -a file_contents=()
+  # shellcheck disable=SC2030,SC2031
+  while IFS='' read -r; do file_contents+=("${REPLY}"); done < "${MISSING_FILE}"
+  [[ ${REPLY} ]] && file_contents+=("${REPLY}")
 
-    [[ "${file_contents[0]}" = "${WORKING_URL_CONTENTS[0]}" ]]
-    [[ "${file_contents[1]}" = "${WORKING_URL_CONTENTS[1]}" ]]
-    [[ "${file_contents[2]}" = "${WORKING_URL_CONTENTS[2]}" ]]
-    [[ "${file_contents[3]}" = "${WORKING_URL_CONTENTS[3]}" ]]
-    [[ "${file_contents[4]}" = "${WORKING_URL_CONTENTS[4]}" ]]
+  [[ "${file_contents[0]}" = "${WORKING_URL_CONTENTS[0]}" ]]
+  [[ "${file_contents[1]}" = "${WORKING_URL_CONTENTS[1]}" ]]
+  [[ "${file_contents[2]}" = "${WORKING_URL_CONTENTS[2]}" ]]
+  [[ "${file_contents[3]}" = "${WORKING_URL_CONTENTS[3]}" ]]
+  [[ "${file_contents[4]}" = "${WORKING_URL_CONTENTS[4]}" ]]
 }
 
 @test "--curl: fail for 404 URL and remove file" {
-    run download --curl \
-        --output-path="${EXISTING_FILE}" \
-        --url="${ERROR_404_URL}"
-    assert_failure
-    assert_output 'Error: download failed.'
-    assert_file_not_exists "${EXISTING_FILE}"
+  run download --curl \
+      --output-path="${EXISTING_FILE}" \
+      --url="${ERROR_404_URL}"
+  assert_failure
+  assert_output 'Error: download failed.'
+  assert_file_not_exists "${EXISTING_FILE}"
 }
 
 @test "--curl: success for user agent change" {
-    # Use a user-agent checking web service.
-    run download --curl --user-agent="${RANDOM_USER_AGENT}" \
-        --url="https://www.whatsmyua.info/"
-    assert_success
-    assert_output --partial "${RANDOM_USER_AGENT}"
+  # Use a user-agent checking web service.
+  run download --curl --user-agent="${RANDOM_USER_AGENT}" \
+      --url="https://www.whatsmyua.info/"
+  assert_success
+  assert_output --partial "${RANDOM_USER_AGENT}"
 }

--- a/test/in-list.bats
+++ b/test/in-list.bats
@@ -6,93 +6,93 @@
 
 # Setup test environment.
 setup() {
-    # Load bats libraries.
-    load 'test_helper/common-setup'
-    _common_setup
+  # Load bats libraries.
+  load 'test_helper/common-setup'
+  _common_setup
 
-    # Sourcing in-list.bash
-    source "${PROJECT_ROOT}/src/in-list.bash"
+  # Sourcing in-list.bash
+  source "${PROJECT_ROOT}/src/in-list.bash"
 }
 
 # Teardown test environment.
 teardown() {
-    _common_teardown
+  _common_teardown
 }
 
 # bats file_tags=function:in-list,scope:public
 
 @test "fail on missing argument" {
-    run in-list
-    assert_failure
-    assert_output "Error: in-list requires at least one argument."
+  run in-list
+  assert_failure
+  assert_output "Error: in-list requires at least one argument."
 }
 
 @test "fail without error message for empty list" {
-    run in-list "text"
-    assert_failure
-    assert_output ""
+  run in-list "text"
+  assert_failure
+  assert_output ""
 }
 
 @test "find text in other arguments" {
-    run in-list "text" "some" "list" "with" "text" "inside"
-    assert_success
-    assert_output ""
+  run in-list "text" "some" "list" "with" "text" "inside"
+  assert_success
+  assert_output ""
 }
 
 @test "find number in other arguments" {
-    run in-list 15 2 5 6 9 10 11 13 15 18 19
-    assert_success
-    assert_output ""
+  run in-list 15 2 5 6 9 10 11 13 15 18 19
+  assert_success
+  assert_output ""
 }
 
 @test "find match in list" {
-    list=("this is" "some argument" "list")
-    run in-list "some argument" "${list[@]}"
-    assert_success
-    assert_output ""
+  list=("this is" "some argument" "list")
+  run in-list "some argument" "${list[@]}"
+  assert_success
+  assert_output ""
 }
 
 @test "Allow for regexp based search (.*)" {
-    list=("a" "word" "in" "this" "test" "list")
-    run in-list "t.*t" "${list[@]}"
-    assert_success
-    assert_output ""
+  list=("a" "word" "in" "this" "test" "list")
+  run in-list "t.*t" "${list[@]}"
+  assert_success
+  assert_output ""
 }
 
 @test "Allow for regexp based search ([a-z]+)" {
-    list=("a" "wooooord" "in" "this" "test" "list")
-    run in-list "w[a-z]+rd" "${list[@]}"
-    assert_success
-    assert_output ""
+  list=("a" "wooooord" "in" "this" "test" "list")
+  run in-list "w[a-z]+rd" "${list[@]}"
+  assert_success
+  assert_output ""
 }
 
 @test "Allow for regexp based search (group)" {
-    list=("a" "word" "in" "this" "test" "list")
-    run in-list "te(x|s)t" "${list[@]}"
-    assert_success
-    assert_output ""
+  list=("a" "word" "in" "this" "test" "list")
+  run in-list "te(x|s)t" "${list[@]}"
+  assert_success
+  assert_output ""
 }
 
 @test "Do not find number in other arguments" {
-    run in-list 15 20 51 63 94 140 121 113 151 138 19
-    assert_failure
-    assert_output ""
+  run in-list 15 20 51 63 94 140 121 113 151 138 19
+  assert_failure
+  assert_output ""
 }
 
 @test "find only exact match in arguments" {
-    run in-list "text" "some" "list" "texts" "inside"
-    assert_failure
-    assert_output ""
+  run in-list "text" "some" "list" "texts" "inside"
+  assert_failure
+  assert_output ""
 }
 
 @test "Do not file partial match in arguments" {
-    run in-list "text" "some" "list" "ext" "inside"
-    assert_failure
-    assert_output ""
+  run in-list "text" "some" "list" "ext" "inside"
+  assert_failure
+  assert_output ""
 }
 
 @test "does not match word in a argument" {
-    run in-list "text" "some" "list" "with text inside"
-    assert_failure
-    assert_output ""
+  run in-list "text" "some" "list" "with text inside"
+  assert_failure
+  assert_output ""
 }

--- a/test/internals/process-long-option.bats
+++ b/test/internals/process-long-option.bats
@@ -4,163 +4,163 @@
 
 # Setup test environment.
 setup() {
-    # Load bats libraries.
-    load '../test_helper/common-setup'
-    _common_setup
+  # Load bats libraries.
+  load '../test_helper/common-setup'
+  _common_setup
 
-    # Sourcing process-options.bash
-    source "${PROJECT_ROOT}/src/internals/process-long-option.bash"
+  # Sourcing process-options.bash
+  source "${PROJECT_ROOT}/src/internals/process-long-option.bash"
 }
 
 # Teardown test environment.
 teardown() {
-    _common_teardown
+  _common_teardown
 }
 
 # bats file_tags=function:process-long-option,scope:private
 
 @test "fail on no arguments" {
-    run process-long-option
-    assert_failure 1
-    assert_output "Error: process-long-option requires only one argument."
+  run process-long-option
+  assert_failure 1
+  assert_output "Error: process-long-option requires only one argument."
 }
 
 @test "fail on 3 arguments" {
-    run process-long-option 1 2
-    assert_failure 1
-    assert_output "Error: process-long-option requires only one argument."
+  run process-long-option 1 2
+  assert_failure 1
+  assert_output "Error: process-long-option requires only one argument."
 }
 
 @test "fail on missing allowed_options environment variable" {
-    run process-long-option "--option"
-    assert_failure 1
-    assert_output "Error: validate-option requires allowed_options variable to be set."
+  run process-long-option "--option"
+  assert_failure 1
+  assert_output "Error: validate-option requires allowed_options variable to be set."
 }
 
 @test "fail on allowed_options environment variable not an array" {
-    allowed_options="not an array"
-    run process-long-option "--option"
-    assert_failure 1
-    assert_output "Error: validate-option requires allowed_options variable to be an array."
+  allowed_options="not an array"
+  run process-long-option "--option"
+  assert_failure 1
+  assert_output "Error: validate-option requires allowed_options variable to be an array."
 }
 
 @test "fail on value without dash" {
-    allowed_options=("o*" "option-with-value")
-    run process-long-option "value"
-    assert_failure 2
-    assert_output ""
+  allowed_options=("o*" "option-with-value")
+  run process-long-option "value"
+  assert_failure 2
+  assert_output ""
 }
 
 @test "fail on unallowed long option" {
-    allowed_options=("o" "option")
-    run process-long-option "--some-option"
-    assert_failure 1
-    assert_output "Error: option '--some-option' is not recognized."
+  allowed_options=("o" "option")
+  run process-long-option "--some-option"
+  assert_failure 1
+  assert_output "Error: option '--some-option' is not recognized."
 }
 
 @test "fail on long option with unallowed value" {
-    allowed_options=("o" "option-with-value")
-    run process-long-option "--option-with-value=value"
-    assert_failure 1
-    assert_output "Error: --option-with-value does not accept arguments."
+  allowed_options=("o" "option-with-value")
+  run process-long-option "--option-with-value=value"
+  assert_failure 1
+  assert_output "Error: --option-with-value does not accept arguments."
 }
 
 @test "fail on mandatory long option with missing mandatory value" {
-    allowed_options=("o" "option-with-value+")
-    run process-long-option "--option-with-value"
-    assert_failure 1
-    assert_output "Error: --option-with-value requires an argument."
+  allowed_options=("o" "option-with-value+")
+  run process-long-option "--option-with-value"
+  assert_failure 1
+  assert_output "Error: --option-with-value requires an argument."
 }
 
 @test "success on mandatory long option with mandatory value" {
-    allowed_options=("o" "option-with-value+")
-    run process-long-option "--option-with-value=some value"
-    assert_success
-    assert_output ""
+  allowed_options=("o" "option-with-value+")
+  run process-long-option "--option-with-value=some value"
+  assert_success
+  assert_output ""
 }
 
 @test "success on mandatory long option with mandatory value (assignation test)" {
-    allowed_options=("o" "option-with-value+")
-    option_with_value=""
-    process-long-option "--option-with-value=some value"
-    assert_equal "${option_with_value}" 'some value'
+  allowed_options=("o" "option-with-value+")
+  option_with_value=""
+  process-long-option "--option-with-value=some value"
+  assert_equal "${option_with_value}" 'some value'
 }
 
 @test "fail on optional long option with missing mandatory value" {
-    allowed_options=("o" "option-with-value&")
-    run process-long-option "--option-with-value"
-    assert_failure 1
-    assert_output "Error: --option-with-value requires an argument."
+  allowed_options=("o" "option-with-value&")
+  run process-long-option "--option-with-value"
+  assert_failure 1
+  assert_output "Error: --option-with-value requires an argument."
 }
 
 @test "success on optional long option with mandatory value" {
-    allowed_options=("o" "option-with-value&")
-    run process-long-option "--option-with-value=some value"
-    assert_success
-    assert_output ""
+  allowed_options=("o" "option-with-value&")
+  run process-long-option "--option-with-value=some value"
+  assert_success
+  assert_output ""
 }
 
 @test "success on optional long option with mandatory value (assignation test)" {
-    allowed_options=("o" "option-with-value&")
-    option_with_value=""
-    process-long-option "--option-with-value=some value"
-    assert_equal "${option_with_value}" 'some value'
+  allowed_options=("o" "option-with-value&")
+  option_with_value=""
+  process-long-option "--option-with-value=some value"
+  assert_equal "${option_with_value}" 'some value'
 }
 
 @test "success on long option with optional value" {
-    allowed_options=("o" "option-with-value*")
-    run process-long-option "--option-with-value=some value"
-    assert_success
-    assert_output ""
+  allowed_options=("o" "option-with-value*")
+  run process-long-option "--option-with-value=some value"
+  assert_success
+  assert_output ""
 }
 
 @test "success on long option with optional value (assignation test)" {
-    allowed_options=("o" "option-with-value*")
-    option_with_value=""
-    process-long-option "--option-with-value=some value"
-    assert_equal "${option_with_value}" 'some value'
+  allowed_options=("o" "option-with-value*")
+  option_with_value=""
+  process-long-option "--option-with-value=some value"
+  assert_equal "${option_with_value}" 'some value'
 }
 
 @test "success on long option without optional value" {
-    allowed_options=("o" "option-with-value*")
-    run process-long-option "--option-with-value"
-    assert_success
-    assert_output ""
+  allowed_options=("o" "option-with-value*")
+  run process-long-option "--option-with-value"
+  assert_success
+  assert_output ""
 }
 
 @test "success on long option without optional value (assignation test)" {
-    allowed_options=("o" "option-with-value*")
-    option_with_value=""
-    process-long-option "--option-with-value"
-    assert_equal "${option_with_value}" 1
+  allowed_options=("o" "option-with-value*")
+  option_with_value=""
+  process-long-option "--option-with-value"
+  assert_equal "${option_with_value}" 1
 }
 
 @test "success on long option without value" {
-    allowed_options=("o" "option-with-value")
-    run process-long-option "--option-with-value"
-    assert_success
-    assert_output ""
+  allowed_options=("o" "option-with-value")
+  run process-long-option "--option-with-value"
+  assert_success
+  assert_output ""
 }
 
 @test "success on long option without value (assignation test)" {
-    allowed_options=("o" "option-with-value")
-    option_with_value=""
-    process-long-option "--option-with-value"
-    assert_equal "${option_with_value}" 1
+  allowed_options=("o" "option-with-value")
+  option_with_value=""
+  process-long-option "--option-with-value"
+  assert_equal "${option_with_value}" 1
 }
 
 @test "success on short option with double dash without value" {
-    allowed_options=("o" "option-with-value")
-    run process-long-option "--o"
-    assert_success
-    assert_output ""
+  allowed_options=("o" "option-with-value")
+  run process-long-option "--o"
+  assert_success
+  assert_output ""
 }
 
 @test "success on short option with double dash without value (assignation test)" {
-    # Disable SC2034 false positive.
-    # shellcheck disable=SC2034
-    allowed_options=("o" "option-with-value")
-    o=""
-    process-long-option "--o"
-    assert_equal "${o}" 1
+  # Disable SC2034 false positive.
+  # shellcheck disable=SC2034
+  allowed_options=("o" "option-with-value")
+  o=""
+  process-long-option "--o"
+  assert_equal "${o}" 1
 }

--- a/test/internals/process-short-options.bats
+++ b/test/internals/process-short-options.bats
@@ -4,88 +4,88 @@
 
 # Setup test environment.
 setup() {
-    # Load bats libraries.
-    load '../test_helper/common-setup'
-    _common_setup
+  # Load bats libraries.
+  load '../test_helper/common-setup'
+  _common_setup
 
-    # Sourcing process-options.bash
-    source "${PROJECT_ROOT}/src/internals/process-short-options.bash"
+  # Sourcing process-options.bash
+  source "${PROJECT_ROOT}/src/internals/process-short-options.bash"
 }
 
 # Teardown test environment.
 teardown() {
-    _common_teardown
+  _common_teardown
 }
 
 # bats file_tags=function:process-short-options,scope:private
 
 @test "fail on no arguments" {
-    run process-short-options
-    assert_failure 1
-    assert_output "Error: process-short-options requires only one argument."
+  run process-short-options
+  assert_failure 1
+  assert_output "Error: process-short-options requires only one argument."
 }
 
 @test "fail on 3 arguments" {
-    run process-short-options 1 2
-    assert_failure 1
-    assert_output "Error: process-short-options requires only one argument."
+  run process-short-options 1 2
+  assert_failure 1
+  assert_output "Error: process-short-options requires only one argument."
 }
 
 @test "fail on missing allowed_options environment variable" {
-    run process-short-options "-option"
-    assert_failure 1
-    assert_output "Error: validate-option requires allowed_options variable to be set."
+  run process-short-options "-option"
+  assert_failure 1
+  assert_output "Error: validate-option requires allowed_options variable to be set."
 }
 
 @test "fail on allowed_options environment variable not an array" {
-    allowed_options="not an array"
-    run process-short-options "-option"
-    assert_failure 1
-    assert_output "Error: validate-option requires allowed_options variable to be an array."
+  allowed_options="not an array"
+  run process-short-options "-option"
+  assert_failure 1
+  assert_output "Error: validate-option requires allowed_options variable to be an array."
 }
 
 @test "fail on value without dash" {
-    allowed_options=("o*" "option-with-value")
-    run process-short-options "value"
-    assert_failure 2
-    assert_output ""
+  allowed_options=("o*" "option-with-value")
+  run process-short-options "value"
+  assert_failure 2
+  assert_output ""
 }
 
 @test "fail on short option with value" {
-    allowed_options=("o*" "option-with-value")
-    run process-short-options "-o=value"
-    assert_failure 2
-    assert_output ""
+  allowed_options=("o*" "option-with-value")
+  run process-short-options "-o=value"
+  assert_failure 2
+  assert_output ""
 }
 
 @test "fail on unallowed short option" {
-    allowed_options=("o" "option")
-    run process-short-options "-os"
-    assert_failure 1
-    assert_output "Error: option '-s' is not recognized."
+  allowed_options=("o" "option")
+  run process-short-options "-os"
+  assert_failure 1
+  assert_output "Error: option '-s' is not recognized."
 }
 
 @test "fail on long option without double dash" {
-    allowed_options=("o" "option-with-value")
-    run process-short-options "-option-with-value"
-    assert_failure
-    assert_output ""
+  allowed_options=("o" "option-with-value")
+  run process-short-options "-option-with-value"
+  assert_failure
+  assert_output ""
 }
 
 @test "success on short option without value" {
-    allowed_options=("o" "k" "option-with-value")
-    run process-short-options "-ok"
-    assert_success
-    assert_output ""
+  allowed_options=("o" "k" "option-with-value")
+  run process-short-options "-ok"
+  assert_success
+  assert_output ""
 }
 
 @test "success on short option without value (assignation test)" {
-    # Disable SC2034 false positive.
-    # shellcheck disable=SC2034
-    allowed_options=("o" "k" "option-with-value")
-    o=""
-    k=""
-    process-short-options "-ok"
-    assert_equal "${o}" 1
-    assert_equal "${k}" 1
+  # Disable SC2034 false positive.
+  # shellcheck disable=SC2034
+  allowed_options=("o" "k" "option-with-value")
+  o=""
+  k=""
+  process-short-options "-ok"
+  assert_equal "${o}" 1
+  assert_equal "${k}" 1
 }

--- a/test/internals/validate-option.bats
+++ b/test/internals/validate-option.bats
@@ -4,161 +4,161 @@
 
 # Setup test environment.
 setup() {
-    # Load bats libraries.
-    load '../test_helper/common-setup'
-    _common_setup
+  # Load bats libraries.
+  load '../test_helper/common-setup'
+  _common_setup
 
-    # Sourcing process-options.bash
-    source "${PROJECT_ROOT}/src/internals/validate-option.bash"
+  # Sourcing process-options.bash
+  source "${PROJECT_ROOT}/src/internals/validate-option.bash"
 }
 
 # Teardown test environment.
 teardown() {
-    _common_teardown
+  _common_teardown
 }
 
 # bats file_tags=function:validate-option,scope:private
 
 @test "fail on no arguments" {
-    run validate-option
-    assert_failure
-    assert_output "Error: validate-option requires one to two arguments."
+  run validate-option
+  assert_failure
+  assert_output "Error: validate-option requires one to two arguments."
 }
 
 @test "fail on 3 arguments" {
-    run validate-option 1 2 3
-    assert_failure
-    assert_output "Error: validate-option requires one to two arguments."
+  run validate-option 1 2 3
+  assert_failure
+  assert_output "Error: validate-option requires one to two arguments."
 }
 
 @test "fail on missing allowed_options environment variable" {
-    run validate-option 1 2
-    assert_failure
-    assert_output "Error: validate-option requires allowed_options variable to be set."
+  run validate-option 1 2
+  assert_failure
+  assert_output "Error: validate-option requires allowed_options variable to be set."
 }
 
 @test "fail on allowed_options environment variable not an array" {
-    allowed_options="not an array"
-    run validate-option 1 2
-    assert_failure
-    assert_output "Error: validate-option requires allowed_options variable to be an array."
+  allowed_options="not an array"
+  run validate-option 1 2
+  assert_failure
+  assert_output "Error: validate-option requires allowed_options variable to be an array."
 }
 
 @test "fail on unallowed long option" {
-    allowed_options=("o" "option")
-    run validate-option "some-option" "value"
-    assert_failure
-    assert_output "Error: option '--some-option' is not recognized."
+  allowed_options=("o" "option")
+  run validate-option "some-option" "value"
+  assert_failure
+  assert_output "Error: option '--some-option' is not recognized."
 }
 
 @test "fail on unallowed short option" {
-    allowed_options=("o" "option")
-    run validate-option "i" "value"
-    assert_failure
-    assert_output "Error: option '-i' is not recognized."
+  allowed_options=("o" "option")
+  run validate-option "i" "value"
+  assert_failure
+  assert_output "Error: option '-i' is not recognized."
 }
 
 @test "fail on long option with unallowed value" {
-    allowed_options=("o" "option-with-value")
-    run validate-option "option-with-value" "value"
-    assert_failure
-    assert_output "Error: --option-with-value does not accept arguments."
+  allowed_options=("o" "option-with-value")
+  run validate-option "option-with-value" "value"
+  assert_failure
+  assert_output "Error: --option-with-value does not accept arguments."
 }
 
 @test "fail on mandatory long option with missing mandatory value" {
-    allowed_options=("o" "option-with-value+")
-    run validate-option "option-with-value"
-    assert_failure
-    assert_output "Error: --option-with-value requires an argument."
+  allowed_options=("o" "option-with-value+")
+  run validate-option "option-with-value"
+  assert_failure
+  assert_output "Error: --option-with-value requires an argument."
 }
 
 @test "success on mandatory long option with mandatory value" {
-    allowed_options=("o" "option-with-value+")
-    run validate-option "option-with-value" "some value"
-    assert_success
-    assert_output ""
+  allowed_options=("o" "option-with-value+")
+  run validate-option "option-with-value" "some value"
+  assert_success
+  assert_output ""
 }
 
 @test "success on mandatory long option with mandatory value (assignation test)" {
-    allowed_options=("o" "option-with-value+")
-    option_with_value=""
-    validate-option "option-with-value" "some value"
-    assert_equal "${option_with_value}" 'some value'
+  allowed_options=("o" "option-with-value+")
+  option_with_value=""
+  validate-option "option-with-value" "some value"
+  assert_equal "${option_with_value}" 'some value'
 }
 
 @test "fail on optional long option with missing mandatory value" {
-    allowed_options=("o" "option-with-value&")
-    run validate-option "option-with-value"
-    assert_failure
-    assert_output "Error: --option-with-value requires an argument."
+  allowed_options=("o" "option-with-value&")
+  run validate-option "option-with-value"
+  assert_failure
+  assert_output "Error: --option-with-value requires an argument."
 }
 
 @test "success on optional long option with mandatory value" {
-    allowed_options=("o" "option-with-value&")
-    run validate-option "option-with-value" "some value"
-    assert_success
-    assert_output ""
+  allowed_options=("o" "option-with-value&")
+  run validate-option "option-with-value" "some value"
+  assert_success
+  assert_output ""
 }
 
 @test "success on optional long option with mandatory value (assignation test)" {
-    allowed_options=("o" "option-with-value&")
-    option_with_value=""
-    validate-option "option-with-value" "some value"
-    assert_equal "${option_with_value}" 'some value'
+  allowed_options=("o" "option-with-value&")
+  option_with_value=""
+  validate-option "option-with-value" "some value"
+  assert_equal "${option_with_value}" 'some value'
 }
 
 @test "success on long option with optional value" {
-    allowed_options=("o" "option-with-value*")
-    run validate-option "option-with-value" "some value"
-    assert_success
-    assert_output ""
+  allowed_options=("o" "option-with-value*")
+  run validate-option "option-with-value" "some value"
+  assert_success
+  assert_output ""
 }
 
 @test "success on long option with optional value (assignation test)" {
-    allowed_options=("o" "option-with-value*")
-    option_with_value=""
-    validate-option "option-with-value" "some value"
-    assert_equal "${option_with_value}" 'some value'
+  allowed_options=("o" "option-with-value*")
+  option_with_value=""
+  validate-option "option-with-value" "some value"
+  assert_equal "${option_with_value}" 'some value'
 }
 
 @test "success on long option without optional value" {
-    allowed_options=("o" "option-with-value*")
-    run validate-option "option-with-value"
-    assert_success
-    assert_output ""
+  allowed_options=("o" "option-with-value*")
+  run validate-option "option-with-value"
+  assert_success
+  assert_output ""
 }
 
 @test "success on long option without optional value (assignation test)" {
-    allowed_options=("o" "option-with-value*")
-    option_with_value=""
-    validate-option "option-with-value"
-    assert_equal "${option_with_value}" 1
+  allowed_options=("o" "option-with-value*")
+  option_with_value=""
+  validate-option "option-with-value"
+  assert_equal "${option_with_value}" 1
 }
 
 @test "success on long option without value" {
-    allowed_options=("o" "option-with-value")
-    run validate-option "option-with-value"
-    assert_success
-    assert_output ""
+  allowed_options=("o" "option-with-value")
+  run validate-option "option-with-value"
+  assert_success
+  assert_output ""
 }
 
 @test "success on long option without value (assignation test)" {
-    allowed_options=("o" "option-with-value")
-    option_with_value=""
-    validate-option "option-with-value"
-    assert_equal "${option_with_value}" 1
+  allowed_options=("o" "option-with-value")
+  option_with_value=""
+  validate-option "option-with-value"
+  assert_equal "${option_with_value}" 1
 }
 
 @test "success on short option without value" {
-    allowed_options=("o" "option-with-value")
-    run validate-option "o"
-    assert_success
-    assert_output ""
+  allowed_options=("o" "option-with-value")
+  run validate-option "o"
+  assert_success
+  assert_output ""
 }
 
 @test "success on short option without value (assignation test)" {
-    allowed_options=("o" "option-with-value")
-    o=""
-    validate-option "o"
-    assert_equal "${o}" 1
+  allowed_options=("o" "option-with-value")
+  o=""
+  validate-option "o"
+  assert_equal "${o}" 1
 }

--- a/test/is-array.bats
+++ b/test/is-array.bats
@@ -6,71 +6,71 @@
 
 # Setup test environment.
 setup() {
-    # Load bats libraries.
-    load 'test_helper/common-setup'
-    _common_setup
+  # Load bats libraries.
+  load 'test_helper/common-setup'
+  _common_setup
 
-    # Sourcing is-array.bash
-    source "${PROJECT_ROOT}/src/is-array.bash"
+  # Sourcing is-array.bash
+  source "${PROJECT_ROOT}/src/is-array.bash"
 }
 
 # Teardown test environment.
 teardown() {
-    _common_teardown
+  _common_teardown
 }
 
 # bats file_tags=function:is-array,scope:public
 
 @test "fail with error on missing argument" {
-    run is-array
-    assert_failure
-    assert_output "Error: is-array requires one and only one argument."
+  run is-array
+  assert_failure
+  assert_output "Error: is-array requires one and only one argument."
 }
 
 @test "fail with error on more than one argument" {
-    run is-array "var1" "var2"
-    assert_failure
-    assert_output "Error: is-array requires one and only one argument."
+  run is-array "var1" "var2"
+  assert_failure
+  assert_output "Error: is-array requires one and only one argument."
 }
 
 @test "fail for string with space" {
-    run is-array "a string"
-    assert_failure
-    assert_output ""
+  run is-array "a string"
+  assert_failure
+  assert_output ""
 }
 
 @test "fail for unset variable" {
-    run is-array "unset_variable"
-    assert_failure
-    assert_output ""
+  run is-array "unset_variable"
+  assert_failure
+  assert_output ""
 }
 
 @test "fail for set variable (int)" {
-    set_variable=10
-    run is-array "set_variable"
-    assert_failure
-    assert_output ""
+  set_variable=10
+  run is-array "set_variable"
+  assert_failure
+  assert_output ""
 }
 
 @test "fail for set variable (string)" {
-    set_variable="string"
-    run is-array "set_variable"
-    assert_failure
-    assert_output ""
+  set_variable="string"
+  run is-array "set_variable"
+  assert_failure
+  assert_output ""
 }
 
 @test "success for set variable (empty array)" {
-    set_variable=()
-    run is-array "set_variable"
-    assert_success
-    assert_output ""
+  set_variable=()
+  run is-array "set_variable"
+  assert_success
+  assert_output ""
 }
 
 @test "success for set variable (array)" {
-    # Disable SC2034 false positive.
-    # shellcheck disable=SC2034
-    set_variable=(1 "2" "three")
-    run is-array "set_variable"
-    assert_success
-    assert_output ""
+  # Disable SC2034 false positive.
+  # shellcheck disable=SC2034
+  set_variable=(1 "2" "three")
+  run is-array "set_variable"
+  assert_success
+  assert_output ""
 }

--- a/test/is-url.bats
+++ b/test/is-url.bats
@@ -6,113 +6,113 @@
 
 # Setup test environment.
 setup() {
-    # Load bats libraries.
-    load 'test_helper/common-setup'
-    _common_setup
+  # Load bats libraries.
+  load 'test_helper/common-setup'
+  _common_setup
 
-    # Sourcing is-url.bash
-    source "${PROJECT_ROOT}/src/is-url.bash"
+  # Sourcing is-url.bash
+  source "${PROJECT_ROOT}/src/is-url.bash"
 }
 
 # Teardown test environment.
 teardown() {
-    _common_teardown
+  _common_teardown
 }
 
 # bats file_tags=function:is-url,scope:public
 
 @test "fail with error on missing argument" {
-    run is-url
-    assert_failure
-    assert_output "Error: is-url requires one and only one argument."
+  run is-url
+  assert_failure
+  assert_output "Error: is-url requires one and only one argument."
 }
 
 @test "fail with error on more than one argument" {
-    run is-url "http://" "https://"
-    assert_failure
-    assert_output "Error: is-url requires one and only one argument."
+  run is-url "http://" "https://"
+  assert_failure
+  assert_output "Error: is-url requires one and only one argument."
 }
 
 @test "success for simple HTTPS URL" {
-    run is-url "https://www.google.com/"
-    assert_success
-    assert_output ""
+  run is-url "https://www.google.com/"
+  assert_success
+  assert_output ""
 }
 
 @test "success for HTTPS URL with one argument" {
-    run is-url "https://www.google.com/search?q=biapy"
-    assert_success
-    assert_output ""
+  run is-url "https://www.google.com/search?q=biapy"
+  assert_success
+  assert_output ""
 }
 
 @test "success for HTTPS URL with two arguments" {
-    run is-url "https://www.google.com/search?q=biapy&hl=en"
-    assert_success
-    assert_output ""
+  run is-url "https://www.google.com/search?q=biapy&hl=en"
+  assert_success
+  assert_output ""
 }
 
 @test "success for well formatted unexistant URL" {
-    run is-url "https://www.my-random-broken-and-inexistant-site.bogus/"
-    assert_success
-    assert_output ""
+  run is-url "https://www.my-random-broken-and-inexistant-site.bogus/"
+  assert_success
+  assert_output ""
 }
 
 @test "success for simple HTTP url" {
-    run is-url "http://www.google.com/"
-    assert_success
-    assert_output ""
+  run is-url "http://www.google.com/"
+  assert_success
+  assert_output ""
 }
 
 @test "success for simple FTP url" {
-    run is-url "ftp://www.google.com/"
-    assert_success
-    assert_output ""
+  run is-url "ftp://www.google.com/"
+  assert_success
+  assert_output ""
 }
 
 @test "success for simple HTTPS url with login and password" {
-    run is-url "https://username:password@www.google.com/"
-    assert_success
-    assert_output ""
+  run is-url "https://username:password@www.google.com/"
+  assert_success
+  assert_output ""
 }
 
 @test "success for simple FILE url" {
-    run is-url "file:///home/"
-    assert_success
-    assert_output ""
+  run is-url "file:///home/"
+  assert_success
+  assert_output ""
 }
 
 @test "fail on simple SSH url" {
-    run is-url "ssh://www.google.com/"
-    assert_failure
-    assert_output ""
+  run is-url "ssh://www.google.com/"
+  assert_failure
+  assert_output ""
 }
 
 @test "fail on simple git url" {
-    run is-url "git://github.com/biapy/biapy-bashlings.git"
-    assert_failure
-    assert_output ""
+  run is-url "git://github.com/biapy/biapy-bashlings.git"
+  assert_failure
+  assert_output ""
 }
 
 @test "success on HTTP url with escaped spaces" {
-    run is-url "http://www.google.com/some%20spaces%20please"
-    assert_success
-    assert_output ""
+  run is-url "http://www.google.com/some%20spaces%20please"
+  assert_success
+  assert_output ""
 }
 
 @test "fail on HTTP url with spaces" {
-    run is-url "http://www.google.com/some spaces please"
-    assert_failure
-    assert_output ""
+  run is-url "http://www.google.com/some spaces please"
+  assert_failure
+  assert_output ""
 }
 
 @test "fail on vscode url" {
-    run is-url "vscode://"
-    assert_failure
-    assert_output ""
+  run is-url "vscode://"
+  assert_failure
+  assert_output ""
 }
 
 @test "fail without error on domain name without protocol" {
-    run is-url "google.com"
-    assert_failure
-    assert_output ""
+  run is-url "google.com"
+  assert_failure
+  assert_output ""
 }

--- a/test/join-array.bats
+++ b/test/join-array.bats
@@ -6,63 +6,63 @@
 
 # Setup test environment.
 setup() {
-    # Load bats libraries.
-    load 'test_helper/common-setup'
-    _common_setup
+  # Load bats libraries.
+  load 'test_helper/common-setup'
+  _common_setup
 
-    # Sourcing join-array.bash
-    source "${PROJECT_ROOT}/src/join-array.bash"
+  # Sourcing join-array.bash
+  source "${PROJECT_ROOT}/src/join-array.bash"
 }
 
 # Teardown test environment.
 teardown() {
-    _common_teardown
+  _common_teardown
 }
 
 # bats file_tags=function:join-array,scope:public
 
 @test "fail with error on missing argument" {
-    run join-array
-    assert_failure
-    assert_output "Error: join-array requires a separator as first argument."
+  run join-array
+  assert_failure
+  assert_output "Error: join-array requires a separator as first argument."
 }
 
 @test "allows separator to be empty" {
-    run join-array '' 'start' 'end'
-    assert_success
-    assert_output 'startend'
+  run join-array '' 'start' 'end'
+  assert_success
+  assert_output 'startend'
 }
 
 @test "allows array to be empty" {
-    run join-array 'separator'
-    assert_success
-    assert_output ''
+  run join-array 'separator'
+  assert_success
+  assert_output ''
 }
 
 @test "allows array to contains only one item" {
-    run join-array 'separator' 'single'
-    assert_success
-    assert_output 'single'
+  run join-array 'separator' 'single'
+  assert_success
+  assert_output 'single'
 }
 
 @test "succeed in joining array contents with string separator" {
-    separator=' separ@tor '
-    declare -a 'long_array'
-    long_array=('first' 2 'third')
-    run join-array "${separator}" ${long_array[@]+"${long_array[@]}"}
-    assert_success
-    assert_output "${long_array[0]-}${separator}${long_array[1]-}${separator}${long_array[2]-}"
+  separator=' separ@tor '
+  declare -a 'long_array'
+  long_array=('first' 2 'third')
+  run join-array "${separator}" ${long_array[@]+"${long_array[@]}"}
+  assert_success
+  assert_output "${long_array[0]-}${separator}${long_array[1]-}${separator}${long_array[2]-}"
 }
 
 @test "success in joining an array with line break" {
-    run join-array '\n' 'first' 'second'
-    assert_success
-    assert_line --index 0 "first"
-    assert_line --index 1 "second"
+  run join-array '\n' 'first' 'second'
+  assert_success
+  assert_line --index 0 "first"
+  assert_line --index 1 "second"
 }
 
 @test "success in joining array with tab" {
-    run join-array '\t' 'first' 'second'
-    assert_success
-    assert_output "$(echo -ne 'first\tsecond')"
+  run join-array '\t' 'first' 'second'
+  assert_success
+  assert_output "$(echo -ne 'first\tsecond')"
 }

--- a/test/join-array.bats
+++ b/test/join-array.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+# join-array.bats
+# Test join-array.bash:join-array function.
+
+# shellcheck source-path=SCRIPTDIR../src
+
+# Setup test environment.
+setup() {
+    # Load bats libraries.
+    load 'test_helper/common-setup'
+    _common_setup
+
+    # Sourcing join-array.bash
+    source "${PROJECT_ROOT}/src/join-array.bash"
+}
+
+# Teardown test environment.
+teardown() {
+    _common_teardown
+}
+
+# bats file_tags=function:join-array,scope:public
+
+@test "fail with error on missing argument" {
+    run join-array
+    assert_failure
+    assert_output "Error: join-array requires a separator as first argument."
+}
+
+@test "allows separator to be empty" {
+    run join-array '' 'start' 'end'
+    assert_success
+    assert_output 'startend'
+}
+
+@test "allows array to be empty" {
+    run join-array 'separator'
+    assert_success
+    assert_output ''
+}
+
+@test "allows array to contains only one item" {
+    run join-array 'separator' 'single'
+    assert_success
+    assert_output 'single'
+}
+
+@test "succeed in joining array contents with string separator" {
+    separator=' separ@tor '
+    declare -a 'long_array'
+    long_array=('first' 2 'third')
+    run join-array "${separator}" ${long_array[@]+"${long_array[@]}"}
+    assert_success
+    assert_output "${long_array[0]-}${separator}${long_array[1]-}${separator}${long_array[2]-}"
+}
+
+@test "success in joining an array with line break" {
+    run join-array '\n' 'first' 'second'
+    assert_success
+    assert_line --index 0 "first"
+    assert_line --index 1 "second"
+}
+
+@test "success in joining array with tab" {
+    run join-array '\t' 'first' 'second'
+    assert_success
+    assert_output "$(echo -ne 'first\tsecond')"
+}

--- a/test/process-options.bats
+++ b/test/process-options.bats
@@ -7,129 +7,129 @@
 
 # Setup test environment.
 setup() {
-    # Load bats libraries.
-    load 'test_helper/common-setup'
-    _common_setup
+  # Load bats libraries.
+  load 'test_helper/common-setup'
+  _common_setup
 
-    # Sourcing process-options.bash
-    source "${PROJECT_ROOT}/src/process-options.bash"
+  # Sourcing process-options.bash
+  source "${PROJECT_ROOT}/src/process-options.bash"
 }
 
 # Teardown test environment.
 teardown() {
-    _common_teardown
+  _common_teardown
 }
 
 # bats file_tags=function:process-options,scope:public
 
 @test "fail on missing argument" {
-    run process-options
-    assert_failure
-    assert_output "Error: process-options requires at least one argument."
+  run process-options
+  assert_failure
+  assert_output "Error: process-options requires at least one argument."
 }
 
 @test "process short option without value and two arguments" {
-    run process-options "o option other-option" -o "argument1" "argument2"
-    assert_success
-    assert_output ""
+  run process-options "o option other-option" -o "argument1" "argument2"
+  assert_success
+  assert_output ""
 }
 
 @test "process short option without value and two arguments (assignation test)" {
-    local arguments=()
-    local o=0
-    process-options "o option other-option" -o "argument1" "argument2"
-    assert_equal "${o}" '1'
-    assert_equal "${arguments[*]}" "argument1 argument2"
+  local arguments=()
+  local o=0
+  process-options "o option other-option" -o "argument1" "argument2"
+  assert_equal "${o}" '1'
+  assert_equal "${arguments[*]}" "argument1 argument2"
 }
 
 @test "process long option without value and two arguments" {
-    run process-options "option other-option" --option "argument1" "argument2"
-    assert_success
-    assert_output ""
+  run process-options "option other-option" --option "argument1" "argument2"
+  assert_success
+  assert_output ""
 }
 
 @test "process long option without value and two arguments (assignation test)" {
-    local arguments=()
-    local option=0
-    process-options "option other-option" --option "argument1" "argument2"
-    assert_equal "${option}" '1'
-    assert_equal "${arguments[*]}" "argument1 argument2"
+  local arguments=()
+  local option=0
+  process-options "option other-option" --option "argument1" "argument2"
+  assert_equal "${option}" '1'
+  assert_equal "${arguments[*]}" "argument1 argument2"
 }
 
 @test "process long option with value and two arguments" {
-    run process-options "option* other-option" --option="value with spaces" \
-        "argument1" "argument2"
-    assert_success
-    assert_output ""
+  run process-options "option* other-option" --option="value with spaces" \
+    "argument1" "argument2"
+  assert_success
+  assert_output ""
 }
 
 @test "process long option with value and two arguments (assignation test)" {
-    local arguments=()
-    local option=0
-    process-options "option* other-option" --option="value with spaces" \
-        "argument1" "argument2"
-    assert_equal "${option}" 'value with spaces'
-    assert_equal "${arguments[*]}" "argument1 argument2"
+  local arguments=()
+  local option=0
+  process-options "option* other-option" --option="value with spaces" \
+    "argument1" "argument2"
+  assert_equal "${option}" 'value with spaces'
+  assert_equal "${arguments[*]}" "argument1 argument2"
 }
 
 @test "process mandatory option with arguments" {
-    run process-options "option+ test set" --option="value with spaces" \
-        "argument1" "argument2"
-    assert_success
-    assert_output ""
+  run process-options "option+ test set" --option="value with spaces" \
+    "argument1" "argument2"
+  assert_success
+  assert_output ""
 }
 
 @test "process mandatory value option with arguments" {
-    run process-options "option& test set" --option="value with spaces" \
-        "argument1" "argument2"
-    assert_success
-    assert_output ""
+  run process-options "option& test set" --option="value with spaces" \
+    "argument1" "argument2"
+  assert_success
+  assert_output ""
 }
 
 @test "process mandatory value option with arguments (assignation test)" {
-    local arguments=()
-    local option=0
-    process-options "option+ test set" --option="value with spaces" \
-        "argument1" "argument2"
-    assert_equal "${option}" 'value with spaces'
-    assert_equal "${arguments[*]}" "argument1 argument2"
+  local arguments=()
+  local option=0
+  process-options "option+ test set" --option="value with spaces" \
+    "argument1" "argument2"
+  assert_equal "${option}" 'value with spaces'
+  assert_equal "${arguments[*]}" "argument1 argument2"
 }
 
 @test "fail on missing mandatory option" {
-    run process-options "option+ test set" --test \
-        "argument1" "argument2"
-    assert_failure
-    assert_output "Error: --option is missing."
+  run process-options "option+ test set" --test \
+    "argument1" "argument2"
+  assert_failure
+  assert_output "Error: --option is missing."
 }
 
 @test "fail on mandatory value option without value" {
-    run process-options "option& test set" --option \
-        "argument1" "argument2"
-    assert_failure
-    assert_output "Error: --option requires an argument."
+  run process-options "option& test set" --option \
+    "argument1" "argument2"
+  assert_failure
+  assert_output "Error: --option requires an argument."
 }
 
 @test "fail on mandatory option without value" {
-    run process-options "option+ test set" --option \
-        "argument1" "argument2"
-    assert_failure
-    assert_output "Error: --option requires an argument."
+  run process-options "option+ test set" --option \
+    "argument1" "argument2"
+  assert_failure
+  assert_output "Error: --option requires an argument."
 }
 
 @test "fail on unallowed short option." {
-    run process-options "o option" -oi --option
-    assert_failure
-    assert_output "Error: option '-i' is not recognized."
+  run process-options "o option" -oi --option
+  assert_failure
+  assert_output "Error: option '-i' is not recognized."
 }
 
 @test "fail on unallowed long option." {
-    run process-options "o i option" -oi --oi9 --option
-    assert_failure
-    assert_output "Error: option '--oi9' is not recognized."
+  run process-options "o i option" -oi --oi9 --option
+  assert_failure
+  assert_output "Error: option '--oi9' is not recognized."
 }
 
 @test "Allow for no arguments beside allowed option list." {
-    run process-options ""
-    assert_success
-    assert_output ""
+  run process-options ""
+  assert_success
+  assert_output ""
 }

--- a/test/realpath-check.bats
+++ b/test/realpath-check.bats
@@ -6,94 +6,94 @@
 
 # Setup test environment.
 setup() {
-    # Load bats libraries.
-    load 'test_helper/common-setup'
-    load 'test_helper/files-setup'
-    _common_setup
-    _files_setup
+  # Load bats libraries.
+  load 'test_helper/common-setup'
+  load 'test_helper/files-setup'
+  _common_setup
+  _files_setup
 
-    # Sourcing realpath-check.bash
-    source "${PROJECT_ROOT}/src/realpath-check.bash"
+  # Sourcing realpath-check.bash
+  source "${PROJECT_ROOT}/src/realpath-check.bash"
 }
 
 # Teardown test environment.
 teardown() {
-    _common_teardown
-    _files_teardown
+  _common_teardown
+  _files_teardown
 }
 
 # bats file_tags=function:realpath-check,scope:public
 
 @test "fail on missing argument" {
-    run realpath-check
-    assert_failure
-    assert_output "Error: realpath-check requires one and only one argument."
+  run realpath-check
+  assert_failure
+  assert_output "Error: realpath-check requires one and only one argument."
 }
 
 @test "fail on more than one argument" {
-    run realpath-check "/path/to/file" "/path/to/other-file"
-    assert_failure
-    assert_output "Error: realpath-check requires one and only one argument."
+  run realpath-check "/path/to/file" "/path/to/other-file"
+  assert_failure
+  assert_output "Error: realpath-check requires one and only one argument."
 }
 
 @test "get realpath-check from complete path" {
-    run realpath-check "${EXISTING_FILE}"
-    assert_success
-    assert_output "${EXISTING_FILE}"
+  run realpath-check "${EXISTING_FILE}"
+  assert_success
+  assert_output "${EXISTING_FILE}"
 }
 
 @test "get realpath-check from relative path" {
-    run realpath-check "${EXISTING_FILE_RELATIVE_PATH}"
-    assert_success
-    assert_output "${EXISTING_FILE}"
+  run realpath-check "${EXISTING_FILE_RELATIVE_PATH}"
+  assert_success
+  assert_output "${EXISTING_FILE}"
 }
 
 @test "get realpath-check from filename" {
-    cd "${EXISTING_FILE%/*}"
-    run realpath-check "${EXISTING_FILE##*/}"
-    assert_success
-    assert_output "${EXISTING_FILE}"
+  cd "${EXISTING_FILE%/*}"
+  run realpath-check "${EXISTING_FILE##*/}"
+  assert_success
+  assert_output "${EXISTING_FILE}"
 }
 
 @test "get realpath-check from filename starting with -" {
-    cd "${EXISTING_DASH_FILE%/*}"
-    run realpath-check -- "${EXISTING_DASH_FILE##*/}"
-    assert_success
-    assert_output "${EXISTING_DASH_FILE}"
+  cd "${EXISTING_DASH_FILE%/*}"
+  run realpath-check -- "${EXISTING_DASH_FILE##*/}"
+  assert_success
+  assert_output "${EXISTING_DASH_FILE}"
 }
 
 @test "fail on missing file" {
-    run realpath-check "${MISSING_FILE}"
-    assert_failure
-    assert_output "Error: File '${MISSING_FILE}' does not exists."
+  run realpath-check "${MISSING_FILE}"
+  assert_failure
+  assert_output "Error: File '${MISSING_FILE}' does not exists."
 }
 
 @test "fail on empty argument" {
-    run realpath-check ""
-    assert_failure
-    assert_output "Error: File '' does not exists."
+  run realpath-check ""
+  assert_failure
+  assert_output "Error: File '' does not exists."
 }
 
 @test "Error message disabled by --quiet" {
-    run realpath-check --quiet ""
-    assert_failure
-    assert_output ""
+  run realpath-check --quiet ""
+  assert_failure
+  assert_output ""
 }
 
 @test "Error message disabled by -q" {
-    run realpath-check -q --q ""
-    assert_failure
-    assert_output ""
+  run realpath-check -q --q ""
+  assert_failure
+  assert_output ""
 }
 
 @test "Error message disabled by -q and --quiet" {
-    run realpath-check -q --quiet ""
-    assert_failure
-    assert_output ""
+  run realpath-check -q --quiet ""
+  assert_failure
+  assert_output ""
 }
 
 @test "fail on invalid option" {
-    run realpath-check --invalid-option
-    assert_failure
-    assert_output "Error: option '--invalid-option' is not recognized."
+  run realpath-check --invalid-option
+  assert_failure
+  assert_output "Error: option '--invalid-option' is not recognized."
 }

--- a/test/realpath.bats
+++ b/test/realpath.bats
@@ -6,154 +6,154 @@
 
 # Setup test environment.
 setup() {
-    # Load bats libraries.
-    load 'test_helper/common-setup'
-    load 'test_helper/files-setup'
-    _common_setup
-    _files_setup
+  # Load bats libraries.
+  load 'test_helper/common-setup'
+  load 'test_helper/files-setup'
+  _common_setup
+  _files_setup
 
-    # Sourcing realpath.bash
-    source "${PROJECT_ROOT}/src/realpath.bash"
+  # Sourcing realpath.bash
+  source "${PROJECT_ROOT}/src/realpath.bash"
 }
 
 # Teardown test environment.
 teardown() {
-    _common_teardown
-    _files_teardown
+  _common_teardown
+  _files_teardown
 }
 
 # bats file_tags=function:realpath
 
 @test "get realpath from complete path" {
-    run realpath "${EXISTING_FILE}"
-    assert_success
-    assert_output "${EXISTING_FILE}"
+  run realpath "${EXISTING_FILE}"
+  assert_success
+  assert_output "${EXISTING_FILE}"
 }
 
 @test "get realpath from relative path" {
-    run realpath "${EXISTING_FILE_RELATIVE_PATH}"
-    assert_success
-    assert_output "${EXISTING_FILE}"
+  run realpath "${EXISTING_FILE_RELATIVE_PATH}"
+  assert_success
+  assert_output "${EXISTING_FILE}"
 }
 
 @test "get realpath from filename" {
-    cd "${EXISTING_FILE%/*}"
-    run realpath "${EXISTING_FILE##*/}"
-    assert_success
-    assert_output "${EXISTING_FILE}"
+  cd "${EXISTING_FILE%/*}"
+  run realpath "${EXISTING_FILE##*/}"
+  assert_success
+  assert_output "${EXISTING_FILE}"
 }
 
 @test "get realpath from filename starting with -" {
-    cd "${EXISTING_DASH_FILE%/*}"
-    run realpath "${EXISTING_DASH_FILE##*/}"
-    assert_success
-    assert_output "${EXISTING_DASH_FILE}"
+  cd "${EXISTING_DASH_FILE%/*}"
+  run realpath "${EXISTING_DASH_FILE##*/}"
+  assert_success
+  assert_output "${EXISTING_DASH_FILE}"
 }
 
 @test "success on missing file" {
-    cd "${MISSING_FILE%/*}"
-    run realpath "${MISSING_FILE##*/}"
-    assert_success
-    assert_output "${MISSING_FILE}"
+  cd "${MISSING_FILE%/*}"
+  run realpath "${MISSING_FILE##*/}"
+  assert_success
+  assert_output "${MISSING_FILE}"
 }
 
 @test "failure on random relative path" {
-    run realpath "random/path/to/file"
-    assert_failure
-    assert_output ""
+  run realpath "random/path/to/file"
+  assert_failure
+  assert_output ""
 }
 
 @test "success on symbolic link to missing file" {
-    cd "${LN_TO_MISSING_FILE%/*}"
-    run realpath "${LN_TO_MISSING_FILE##*/}"
-    assert_success
-    assert_output "${MISSING_FILE}"
+  cd "${LN_TO_MISSING_FILE%/*}"
+  run realpath "${LN_TO_MISSING_FILE##*/}"
+  assert_success
+  assert_output "${MISSING_FILE}"
 }
 
 @test "fail on empty argument" {
-    run realpath ""
-    assert_failure
-    assert_output ""
+  run realpath ""
+  assert_failure
+  assert_output ""
 }
 
 @test "fail on missing argument" {
-    run realpath
-    assert_failure
-    assert_output "Error: realpath requires one and only one argument."
+  run realpath
+  assert_failure
+  assert_output "Error: realpath requires one and only one argument."
 }
 
 @test "fail on more than one argument" {
-    run realpath "/path/to/file" "/path/to/other-file"
-    assert_failure
-    assert_output "Error: realpath requires one and only one argument."
+  run realpath "/path/to/file" "/path/to/other-file"
+  assert_failure
+  assert_output "Error: realpath requires one and only one argument."
 }
 
 @test "get realpath from complete path using pure bash" {
-    run realpath --pure-bash "${EXISTING_FILE}"
-    assert_success
-    assert_output "${EXISTING_FILE}"
+  run realpath --pure-bash "${EXISTING_FILE}"
+  assert_success
+  assert_output "${EXISTING_FILE}"
 }
 
 @test "get realpath from relative path using pure bash" {
-    run realpath --pure-bash "${EXISTING_FILE_RELATIVE_PATH}"
-    assert_success
-    assert_output "${EXISTING_FILE}"
+  run realpath --pure-bash "${EXISTING_FILE_RELATIVE_PATH}"
+  assert_success
+  assert_output "${EXISTING_FILE}"
 }
 
 @test "get realpath from filename using pure bash" {
-    cd "${EXISTING_FILE%/*}"
-    run realpath --pure-bash "${EXISTING_FILE##*/}"
-    assert_success
-    assert_output "${EXISTING_FILE}"
+  cd "${EXISTING_FILE%/*}"
+  run realpath --pure-bash "${EXISTING_FILE##*/}"
+  assert_success
+  assert_output "${EXISTING_FILE}"
 }
 
 @test "get realpath from filename starting with - using pure bash" {
-    cd "${EXISTING_DASH_FILE%/*}"
-    run realpath --pure-bash "${EXISTING_DASH_FILE##*/}"
-    assert_success
-    assert_output "${EXISTING_DASH_FILE}"
+  cd "${EXISTING_DASH_FILE%/*}"
+  run realpath --pure-bash "${EXISTING_DASH_FILE##*/}"
+  assert_success
+  assert_output "${EXISTING_DASH_FILE}"
 }
 
 @test "success on missing file using pure bash" {
-    cd "${MISSING_FILE%/*}"
-    run realpath --pure-bash "${MISSING_FILE##*/}"
-    assert_success
-    assert_output "${MISSING_FILE}"
+  cd "${MISSING_FILE%/*}"
+  run realpath --pure-bash "${MISSING_FILE##*/}"
+  assert_success
+  assert_output "${MISSING_FILE}"
 }
 
 @test "failure on random relative path using pure bash" {
-    run realpath --pure-bash "random/path/to/file"
-    assert_failure
-    assert_output ""
+  run realpath --pure-bash "random/path/to/file"
+  assert_failure
+  assert_output ""
 }
 
 @test "success on symbolic link to missing file using pure bash" {
-    cd "${LN_TO_MISSING_FILE%/*}"
-    run realpath --pure-bash "${LN_TO_MISSING_FILE##*/}"
-    assert_success
-    assert_output "${MISSING_FILE}"
+  cd "${LN_TO_MISSING_FILE%/*}"
+  run realpath --pure-bash "${LN_TO_MISSING_FILE##*/}"
+  assert_success
+  assert_output "${MISSING_FILE}"
 }
 
 @test "fail on empty argument using pure bash" {
-    run realpath --pure-bash ""
-    assert_failure
-    assert_output ""
+  run realpath --pure-bash ""
+  assert_failure
+  assert_output ""
 }
 
 @test "fail on non existing root path using pure bash" {
-    run realpath --pure-bash "${MISSING_ABSOLUTE_PATH}"
-    assert_failure
-    assert_output ""
+  run realpath --pure-bash "${MISSING_ABSOLUTE_PATH}"
+  assert_failure
+  assert_output ""
 }
 
 @test "fail on missing argument using pure bash" {
-    run realpath --pure-bash
-    assert_failure
-    assert_output "Error: realpath requires one and only one argument."
+  run realpath --pure-bash
+  assert_failure
+  assert_output "Error: realpath requires one and only one argument."
 }
 
 @test "fail on more than one argument using pure bash" {
-    run realpath --pure-bash "/path/to/file" "/path/to/other-file"
-    assert_failure
-    assert_output "Error: realpath requires one and only one argument."
+  run realpath --pure-bash "/path/to/file" "/path/to/other-file"
+  assert_failure
+  assert_output "Error: realpath requires one and only one argument."
 }

--- a/test/repeat-string.bats
+++ b/test/repeat-string.bats
@@ -51,6 +51,12 @@ teardown() {
     assert_output "repeatrepeatrepeat"
 }
 
+@test "success in repeating a string 0 times" {
+    run repeat-string '0' 'repeat'
+    assert_success
+    assert_output ""
+}
+
 @test "success in repeating a string with line break" {
     run repeat-string '3' "$(echo -e "line\nnext ")"
     assert_success

--- a/test/repeat-string.bats
+++ b/test/repeat-string.bats
@@ -6,62 +6,62 @@
 
 # Setup test environment.
 setup() {
-    # Load bats libraries.
-    load 'test_helper/common-setup'
-    _common_setup
+  # Load bats libraries.
+  load 'test_helper/common-setup'
+  _common_setup
 
-    # Sourcing repeat-string.bash
-    source "${PROJECT_ROOT}/src/repeat-string.bash"
+  # Sourcing repeat-string.bash
+  source "${PROJECT_ROOT}/src/repeat-string.bash"
 }
 
 # Teardown test environment.
 teardown() {
-    _common_teardown
+  _common_teardown
 }
 
 # bats file_tags=function:repeat-string,scope:public
 
 @test "fail with error on missing argument" {
-    run repeat-string 'first'
-    assert_failure
-    assert_output "Error: repeat-string requires two and only two arguments."
+  run repeat-string 'first'
+  assert_failure
+  assert_output "Error: repeat-string requires two and only two arguments."
 }
 
 @test "fail with error on more than two arguments" {
-    run repeat-string 'first' 'second' 'third'
-    assert_failure
-    assert_output "Error: repeat-string requires two and only two arguments."
+  run repeat-string 'first' 'second' 'third'
+  assert_failure
+  assert_output "Error: repeat-string requires two and only two arguments."
 }
 
 @test "fail with error if first argument is empty" {
-    run repeat-string '' 'repeat'
-    assert_failure
-    assert_output "Error: repeat-string's first argument is not an integer."
+  run repeat-string '' 'repeat'
+  assert_failure
+  assert_output "Error: repeat-string's first argument is not an integer."
 }
 
 @test "fail with error if first argument is not an integer" {
-    run repeat-string 'string' 'repeat'
-    assert_failure
-    assert_output "Error: repeat-string's first argument is not an integer."
+  run repeat-string 'string' 'repeat'
+  assert_failure
+  assert_output "Error: repeat-string's first argument is not an integer."
 }
 
 @test "success in repeating a string" {
-    run repeat-string '3' 'repeat'
-    assert_success
-    assert_output "repeatrepeatrepeat"
+  run repeat-string '3' 'repeat'
+  assert_success
+  assert_output "repeatrepeatrepeat"
 }
 
 @test "success in repeating a string 0 times" {
-    run repeat-string '0' 'repeat'
-    assert_success
-    assert_output ""
+  run repeat-string '0' 'repeat'
+  assert_success
+  assert_output ""
 }
 
 @test "success in repeating a string with line break" {
-    run repeat-string '3' "$(printf '%b' "line\nnext ")"
-    assert_success
-    assert_line --index 0 "line"
-    assert_line --index 1 "next line"
-    assert_line --index 2 "next line"
-    assert_line --index 3 "next "
+  run repeat-string '3' "$(printf '%b' "line\nnext ")"
+  assert_success
+  assert_line --index 0 "line"
+  assert_line --index 1 "next line"
+  assert_line --index 2 "next line"
+  assert_line --index 3 "next "
 }

--- a/test/repeat-string.bats
+++ b/test/repeat-string.bats
@@ -58,7 +58,7 @@ teardown() {
 }
 
 @test "success in repeating a string with line break" {
-    run repeat-string '3' "$(echo -e "line\nnext ")"
+    run repeat-string '3' "$(printf '%b' "line\nnext ")"
     assert_success
     assert_line --index 0 "line"
     assert_line --index 1 "next line"

--- a/test/test_helper/common-setup.bash
+++ b/test/test_helper/common-setup.bash
@@ -5,41 +5,41 @@
 # Set PROJECT_ROOT environment variable.
 # Add PROJECT_ROOT/src to PATH.
 _common_setup() {
-    # Apply The Sharat's recommendations
-    # See [Shell Script Best Practices](https://sharats.me/posts/shell-script-best-practices/)
-    set -o errexit
-    set -o nounset
-    set -o pipefail
+  # Apply The Sharat's recommendations
+  # See [Shell Script Best Practices](https://sharats.me/posts/shell-script-best-practices/)
+  set -o errexit
+  set -o nounset
+  set -o pipefail
 
-    if [[ "${TRACE-0}" == "1" ]]; then
-      set -o xtrace
-    fi
+  if [[ "${TRACE-0}" == "1" ]]; then
+    set -o xtrace
+  fi
 
-    # Load bats-support helper library.
-    if [[ -e "${BASH_SOURCE[0]%/*}/bats-support/load.bash" ]]; then
-      load "${BASH_SOURCE[0]%/*}/bats-support/load"
-    elif [[ -e "/usr/lib/bats-support/load.bash" ]]; then
-      load "/usr/lib/bats-support/load"
-    fi
+  # Load bats-support helper library.
+  if [[ -e "${BASH_SOURCE[0]%/*}/bats-support/load.bash" ]]; then
+    load "${BASH_SOURCE[0]%/*}/bats-support/load"
+  elif [[ -e "/usr/lib/bats-support/load.bash" ]]; then
+    load "/usr/lib/bats-support/load"
+  fi
 
-    # Load bats-assert helper library.
-    if [[ -e "${BASH_SOURCE[0]%/*}/bats-assert/load.bash" ]]; then
-      load "${BASH_SOURCE[0]%/*}/bats-assert/load"
-    elif [[ -e "/usr/lib/bats-assert/load.bash" ]]; then
-      load "/usr/lib/bats-assert/load"
-    fi
+  # Load bats-assert helper library.
+  if [[ -e "${BASH_SOURCE[0]%/*}/bats-assert/load.bash" ]]; then
+    load "${BASH_SOURCE[0]%/*}/bats-assert/load"
+  elif [[ -e "/usr/lib/bats-assert/load.bash" ]]; then
+    load "/usr/lib/bats-assert/load"
+  fi
 
-    # get the containing directory of this file
-    # use $BATS_TEST_FILENAME instead of ${BASH_SOURCE[0]} or $0,
-    # as those will point to the bats executable's location or the preprocessed file respectively
-    # shellcheck disable=SC2154
-    PROJECT_ROOT="$( cd "${BATS_TEST_FILENAME%\/test\/*}/" >/dev/null 2>&1 && pwd )"
-    # make executables in src/ visible to PATH
-    PATH="${PROJECT_ROOT}/src:${PATH}"
+  # get the containing directory of this file
+  # use $BATS_TEST_FILENAME instead of ${BASH_SOURCE[0]} or $0,
+  # as those will point to the bats executable's location or the preprocessed file respectively
+  # shellcheck disable=SC2154
+  PROJECT_ROOT="$( cd "${BATS_TEST_FILENAME%\/test\/*}/" >/dev/null 2>&1 && pwd )"
+  # make executables in src/ visible to PATH
+  PATH="${PROJECT_ROOT}/src:${PATH}"
 }
 
 # Common test environment teardown.
 _common_teardown() {
-    # Nothing to teardown.
-    echo -n ""
+  # Nothing to teardown.
+  echo -n ""
 }

--- a/test/test_helper/files-setup.bash
+++ b/test/test_helper/files-setup.bash
@@ -2,53 +2,53 @@
 
 # Files test environment setup.
 _files_setup() {
-    # Load bats-file helper library.
-    if [[ -e "${BASH_SOURCE[0]%/*}/bats-file/load.bash" ]]; then
-      load "${BASH_SOURCE[0]%/*}/bats-file/load"
-    elif [[ -e "/usr/lib/bats-file/load.bash" ]]; then
-      load "/usr/lib/bats-file/load"
-    fi
+  # Load bats-file helper library.
+  if [[ -e "${BASH_SOURCE[0]%/*}/bats-file/load.bash" ]]; then
+    load "${BASH_SOURCE[0]%/*}/bats-file/load"
+  elif [[ -e "/usr/lib/bats-file/load.bash" ]]; then
+    load "/usr/lib/bats-file/load"
+  fi
 
-    local prefix=""
+  local prefix=""
 
-    EXISTING_FILE="$( mktemp )"
-    
-    # On MacOS /var is a symbolic link to /private/var.
-    if [[ -e "/private${EXISTING_FILE}" ]]; then
-      prefix="/private"
-      EXISTING_FILE="${prefix}${EXISTING_FILE}"
-    fi
+  EXISTING_FILE="$( mktemp )"
+  
+  # On MacOS /var is a symbolic link to /private/var.
+  if [[ -e "/private${EXISTING_FILE}" ]]; then
+    prefix="/private"
+    EXISTING_FILE="${prefix}${EXISTING_FILE}"
+  fi
 
-    MISSING_FILE="${prefix}$( mktemp -u )"
-    LN_TO_MISSING_FILE="${prefix}$( mktemp -u )"
-    ln -s "${MISSING_FILE}" "${LN_TO_MISSING_FILE}"
+  MISSING_FILE="${prefix}$( mktemp -u )"
+  LN_TO_MISSING_FILE="${prefix}$( mktemp -u )"
+  ln -s "${MISSING_FILE}" "${LN_TO_MISSING_FILE}"
 
-    # shellcheck disable=SC2034
-    EXISTING_DASH_FILE="${prefix}$( mktemp -t -- '-tmp.XXXXXXXXX' )"
-    LN_TO_EXISTING_FILE="${prefix}$( mktemp -u )"
-    ln -s "${EXISTING_FILE}" "${LN_TO_EXISTING_FILE}"
+  # shellcheck disable=SC2034
+  EXISTING_DASH_FILE="${prefix}$( mktemp -t -- '-tmp.XXXXXXXXX' )"
+  LN_TO_EXISTING_FILE="${prefix}$( mktemp -u )"
+  ln -s "${EXISTING_FILE}" "${LN_TO_EXISTING_FILE}"
 
-    EXISTING_FILE_DIRNAME="${EXISTING_FILE%/*}"
-    EXISTING_FILE_BASENAME="${EXISTING_FILE##*/}"
-    # shellcheck disable=SC2034
-    EXISTING_FILE_RELATIVE_PATH="${EXISTING_FILE_DIRNAME}/./${EXISTING_FILE_BASENAME}"
+  EXISTING_FILE_DIRNAME="${EXISTING_FILE%/*}"
+  EXISTING_FILE_BASENAME="${EXISTING_FILE##*/}"
+  # shellcheck disable=SC2034
+  EXISTING_FILE_RELATIVE_PATH="${EXISTING_FILE_DIRNAME}/./${EXISTING_FILE_BASENAME}"
 
-    # Create an absolute path with missing root directory.
-    RANDOM_MISSING_FILE="${MISSING_FILE}"
-    while [[ -e "/${RANDOM_MISSING_FILE##*/}" ]]; do
-      RANDOM_MISSING_FILE="${prefix}$( mktemp -u )"
-    done
-    # shellcheck disable=SC2034
-    MISSING_ABSOLUTE_PATH="${RANDOM_MISSING_FILE##*/}/${EXISTING_FILE_BASENAME}"
+  # Create an absolute path with missing root directory.
+  RANDOM_MISSING_FILE="${MISSING_FILE}"
+  while [[ -e "/${RANDOM_MISSING_FILE##*/}" ]]; do
+    RANDOM_MISSING_FILE="${prefix}$( mktemp -u )"
+  done
+  # shellcheck disable=SC2034
+  MISSING_ABSOLUTE_PATH="${RANDOM_MISSING_FILE##*/}/${EXISTING_FILE_BASENAME}"
 }
 
 # Files test environment teardown.
 _files_teardown() {
-    [[ -e "${MISSING_FILE}" ]] && rm "${MISSING_FILE}"
-    [[ -e "${LN_TO_MISSING_FILE}" ]] && rm "${LN_TO_MISSING_FILE}"
-    
-    [[ -e "${EXISTING_FILE}" ]] && rm "${EXISTING_FILE}"
-    [[ -e "${LN_TO_EXISTING_FILE}" ]] && rm "${LN_TO_EXISTING_FILE}"
+  [[ -e "${MISSING_FILE}" ]] && rm "${MISSING_FILE}"
+  [[ -e "${LN_TO_MISSING_FILE}" ]] && rm "${LN_TO_MISSING_FILE}"
+  
+  [[ -e "${EXISTING_FILE}" ]] && rm "${EXISTING_FILE}"
+  [[ -e "${LN_TO_EXISTING_FILE}" ]] && rm "${LN_TO_EXISTING_FILE}"
 
-    return 0
+  return 0
 }


### PR DESCRIPTION
- Add `join-array` function for joining an array content by a string (like PHP `implode`).
- Add `available-fd` function to look for available file descriptor with `bash` < 4.1 (e.g. macOS).
- Update `skeleton.bash` to make use of `available-fd`.
